### PR TITLE
Set an env var after fetching the version from the Pulumi

### DIFF
--- a/buildAndReleaseTask/index.ts
+++ b/buildAndReleaseTask/index.ts
@@ -8,7 +8,7 @@ import { installUsingCurl } from "./installers/curl";
 import { installUsingPowerShell } from "./installers/powershell";
 import { runPulumi } from "./pulumi";
 import { getServiceEndpoint } from "./serviceEndpoint";
-import { getLatestPulumiVersion } from "./version";
+import { ENV_PULUMI_VERSION, getLatestPulumiVersion } from "./version";
 
 let pulumiVersion: string;
 
@@ -17,7 +17,13 @@ async function run() {
 
     tl.debug(tl.loc("Debug_Starting"));
 
-    pulumiVersion = await getLatestPulumiVersion();
+    const versionVariable = tl.getVariable(ENV_PULUMI_VERSION);
+    if (versionVariable) {
+        pulumiVersion = versionVariable;
+        tl.debug(tl.loc("Debug_DetectedVersion", pulumiVersion));
+    } else {
+        pulumiVersion = await getLatestPulumiVersion();
+    }
 
     const connectedServiceName = tl.getInput("azureSubscription", true);
 

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -82,6 +82,7 @@
         "Debug_ServiceEndpointName": "Using service endpoint '%s'.",
         "Debug_TempDirectoryNotSet": "agent.tempdirectory not set. Using $HOME/temp.",
         "Debug_LatestPulumiVersion": "Latest pulumi version from https://pulumi.io/latest-version is '%s'.",
-        "Debug_CachingPulumiToHome": "Caching pulumi CLI to path '%s'."
+        "Debug_CachingPulumiToHome": "Caching pulumi CLI to path '%s'.",
+        "Debug_DetectedVersion": "PULUMI_VERSION variable detected in the environment as '%s'. Task will use this version from the local tool cache."
     }
 }

--- a/buildAndReleaseTask/tests/success.ts
+++ b/buildAndReleaseTask/tests/success.ts
@@ -31,6 +31,7 @@ tmr.registerMock("./serviceEndpoint", {
 });
 
 tmr.registerMock("./version", {
+    ENV_PULUMI_VERSION: "DOESNT-MATTER",
     getLatestPulumiVersion: (): Promise<string> => {
         return Promise.resolve(pulumiVersion);
     },

--- a/buildAndReleaseTask/version.ts
+++ b/buildAndReleaseTask/version.ts
@@ -3,6 +3,8 @@
 import * as axios from "axios";
 import * as tl from "azure-pipelines-task-lib/task";
 
+export const ENV_PULUMI_VERSION = "PULUMI_VERSION";
+
 export async function getLatestPulumiVersion(): Promise<string> {
     const resp = await axios.default.get<string>("https://pulumi.io/latest-version", {
         headers: {
@@ -13,5 +15,7 @@ export async function getLatestPulumiVersion(): Promise<string> {
     // The response contains a new-line character at the end, so let's replace it.
     const version = resp.data.replace("\n", "");
     tl.debug(tl.loc("Debug_LatestPulumiVersion", version));
+    // Set the version in the env var, so that subsequent tasks know which version to check in the tool cache.
+    tl.setVariable(ENV_PULUMI_VERSION, version);
     return version;
 }


### PR DESCRIPTION
This will allow subsequent tasks to use this version string when querying the tool cache, and thus avoiding another network request to fetch the version number, since an instance of task in a preceding step would have installed pulumi with a certain version number already and subsequent steps should just use that from the tool cache, instead of fetching the same version (or in some edge case scenario, a completely different version.)