### PR TITLE
Make command picklist of allowed commands

### DIFF
--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 16
+        "Patch": 20
     },
     "instanceNameFormat": "Run pulumi $(pulCommand) $(pulArgs)",
     "inputs": [
@@ -27,11 +27,20 @@
         },
         {
             "name": "command",
-            "type": "string",
+            "type": "pickList",
             "label": "Pulumi Command",
             "defaultValue": "",
             "helpMarkDown": "For a list of CLI commands and arguments, see [this](https://pulumi.io/reference/commands.html).",
-            "required": "true"
+            "required": "true",
+            "options": {
+                "new": "new",
+                "init": "init",
+                "stack": "stack",
+                "config": "config",
+                "up": "up",
+                "preview": "preview",
+                "destroy": "destroy"
+            }
         },
         {
             "name": "args",

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -32,6 +32,9 @@
             "defaultValue": "",
             "helpMarkDown": "For a list of CLI commands and arguments, see [this](https://pulumi.io/reference/commands.html).",
             "required": "true",
+            "properties": {
+                "EditableOptions": "True"
+            },
             "options": {
                 "new": "new",
                 "init": "init",

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 20
+        "Patch": 16
     },
     "instanceNameFormat": "Run pulumi $(pulCommand) $(pulArgs)",
     "inputs": [


### PR DESCRIPTION
This PR should enhance the UX a bit by making the command `string` a `pickList` of all allowed commands for the pulumi binary.

Good idea? 