### PR TITLE
Set PULUMI_CONFIG_PASSPHRASE in the exec options

### DIFF
--- a/buildAndReleaseTask/installers/pulumi.ts
+++ b/buildAndReleaseTask/installers/pulumi.ts
@@ -12,7 +12,7 @@ import * as path from "path";
  * @param latestPulumiVersion latest version based on what `getLatestPulumiVersion` returned.
  */
 
-export async function installPulumi(versionSpec: string, latestPulumiVersion: string) {
+export async function installPulumi(versionSpec: string, latestPulumiVersion: string): Promise<string> {
     const os = tl.osType();
     tl.debug(tl.loc("OSDETECTED", os));
 
@@ -32,6 +32,8 @@ export async function installPulumi(versionSpec: string, latestPulumiVersion: st
         default:
             throw new Error(`Unexpected OS "${os.toLowerCase()}"`);
     }
+
+    return versionSpec;
 }
 
 async function installPulumiWindows(version: string) {

--- a/buildAndReleaseTask/package-lock.json
+++ b/buildAndReleaseTask/package-lock.json
@@ -73,12 +73,12 @@
       }
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "1.7.0",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "2.0.3"
       }
     },
     "azure-pipelines-task-lib": {
@@ -190,11 +190,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
-        "ms": "2.1.1"
+        "ms": "2.0.0"
       }
     },
     "diff": {
@@ -222,11 +222,11 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "3.2.6"
+        "debug": "3.1.0"
       }
     },
     "fs.realpath": {
@@ -272,9 +272,9 @@
       "dev": true
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -321,9 +321,9 @@
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "once": {
       "version": "1.4.0",

--- a/buildAndReleaseTask/package.json
+++ b/buildAndReleaseTask/package.json
@@ -12,7 +12,7 @@
   "author": "Pulumi",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "azure-pipelines-task-lib": "^2.8.0",
     "azure-pipelines-tool-lib": "^0.12.0",
     "typed-rest-client": "^1.2.0"

--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -3,8 +3,8 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tr from "azure-pipelines-task-lib/toolrunner";
 
-import { IServiceEndpoint } from "serviceEndpoint";
-import { PULUMI_ACCESS_TOKEN, PULUMI_CONFIG_PASSPHRASE } from "vars";
+import { IServiceEndpoint } from "./serviceEndpoint";
+import { PULUMI_ACCESS_TOKEN, PULUMI_CONFIG_PASSPHRASE } from "./vars";
 
 async function selectStack(toolPath: string, pulExecOptions: tr.IExecOptions) {
     const pulStack = tl.getInput("stack", true);

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -94,6 +94,7 @@
         "PulumiCommandFailed": "Pulumi command exited with code '%s' while trying to run '%s'.",
         "PulumiStackSelectFailed": "Failed to select the stack '%s'.",
         "PulumiAccessTokenNotFailed": "Pulumi access token could not be determined. Set PULUMI_ACCESS_TOKEN as a secret env variable.",
+        "DetectedVersion": "%s variable detected with value '%s'. Task will use this version from the local tool cache.",
         "Debug_NotFoundInCache": "Pulumi not found in the local tool cache. Will download and install it.",
         "Debug_Starting": "Starting..",
         "Debug_AddedToPATH": "Added Pulumi to PATH.",
@@ -105,6 +106,6 @@
         "Debug_TempDirectoryNotSet": "agent.tempdirectory not set. Using $HOME/temp.",
         "Debug_LatestPulumiVersion": "Latest pulumi version from https://pulumi.io/latest-version is '%s'.",
         "Debug_CachingPulumiToHome": "Caching pulumi CLI to path '%s'.",
-        "Debug_ExpectedPulumiVersion": "Requested Pulumi version is '%s'."
+        "Debug_ExpectedPulumiVersion": "Requested Pulumi version is '%s'.",
     }
 }

--- a/buildAndReleaseTask/vars.ts
+++ b/buildAndReleaseTask/vars.ts
@@ -1,0 +1,19 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+/**
+ * This file contains the various environment variables set by the task extension.
+ */
+
+// INSTALLED_PULUMI_VERSION is set after a version of the CLI has been installed successfully.
+export const INSTALLED_PULUMI_VERSION = "INSTALLED_PULUMI_VERSION";
+
+// PULUMI_ACCESS_TOKEN is used by the Pulumi CLI to login into an account non-interactively.
+export const PULUMI_ACCESS_TOKEN = "PULUMI_ACCESS_TOKEN";
+/**
+ * PULUMI_CONFIG_PASSPHRASE is used to specify the passphrase used by the secrets provider
+ * to be able to decrypt a secret that was previously encrypted by deriving a key
+ * from the same passphrase.
+ *
+ * See https://blog.pulumi.com/managing-secrets-with-pulumi to learn more about encrypted configuration properties.
+ */
+export const PULUMI_CONFIG_PASSPHRASE = "PULUMI_CONFIG_PASSPHRASE";


### PR DESCRIPTION
- Set PULUMI_CONFIG_PASSPHRASE in the exec options.
- Set the installed pulumi version so that subsequent instances of the same task can just reuse the version of the CLI that was installed by a preceding instance of the task.