### PR TITLE
Allow DOTNET_CLI_HOME to be set for the Pulumi CLI

### DIFF
--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -178,6 +178,7 @@ export async function runPulumi() {
         const dotnetCliHome =
             tl.getVariable("dotnet.cli.home") ||
             tl.getVariable("DOTNET_CLI_HOME") ||
+            tl.getVariable("Agent.TempDirectory") ||
             "";
         envVars["DOTNET_CLI_HOME"] = dotnetCliHome;
         const pulExecOptions = getExecOptions(envVars, pulCwd);

--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -175,6 +175,11 @@ export async function runPulumi() {
             tl.getVariable("SECRET_PULUMI_CONFIG_PASSPHRASE") ||
             "";
         envVars[PULUMI_CONFIG_PASSPHRASE] = pulumiConfigPassphrase;
+        const dotnetCliHome =
+            tl.getVariable("dotnet.cli.home") ||
+            tl.getVariable("DOTNET_CLI_HOME") ||
+            "";
+        envVars["DOTNET_CLI_HOME"] = dotnetCliHome;
         const pulExecOptions = getExecOptions(envVars, pulCwd);
 
         // Select the stack.


### PR DESCRIPTION
Fixes #23.

On build agents, the `HOME` env var is not set and this causes the [dotnet CLI to fail](https://github.com/dotnet/cli/issues/8053). Use the built-in fallback `Agent.TempDirectory` if `DOTNET_CLI_HOME` itself is not defined and if all else fails, let the Pulumi CLI fail too, so that the user can set an appropriate home path for the dotnet CLI.