### PR TITLE
Add a new task param for specifying login args.

### DIFF
--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -50,7 +50,7 @@
             "type": "string",
             "label": "Login Args",
             "defaultValue": "",
-            "helpMarkDown": "Specify the args to be passed to the `pulumi login` command. Use space to separate multiple args. For a list of CLI commands and arguments, see [this](https://www.pulumi.com/docs/reference/cli/).",
+            "helpMarkDown": "Specify the args to be passed to the `pulumi login` command. Use space to separate multiple args. Learn more [here](https://www.pulumi.com/docs/reference/cli/pulumi_login/).",
             "required": "false"
         },
         {

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -46,6 +46,14 @@
             }
         },
         {
+            "name": "loginArgs",
+            "type": "string",
+            "label": "Login Args",
+            "defaultValue": "",
+            "helpMarkDown": "Specify the args to be passed to the `pulumi login` command. Use space to separate multiple args. For a list of CLI commands and arguments, see [this](https://www.pulumi.com/docs/reference/cli/).",
+            "required": "false"
+        },
+        {
             "name": "args",
             "type": "string",
             "label": "Pulumi Args",


### PR DESCRIPTION
This PR adds a new (optional) task extension param, that allows a user to pass args to the `login` command. This is useful for specifying args that are only applicable to the `login` command.