### PR TITLE
Assign full Node process.env map to the exec options for the tool runner

### DIFF
--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -148,7 +148,8 @@ export async function runPulumi() {
 
         /**
          * `process.env` only contains "public" variables, i.e. system and agent variables that
-         * are not secret. Secret vars can only be retrieved using `tl.getVariable` or `tl.getVariables`.
+         * are not secret. Secret vars can only be retrieved using `tl.getVariable` or
+         * `tl.getVariables`.
          */
         const processEnv = process.env as IEnvMap;
         tl.debug(`Executing Pulumi commands with process env ${JSON.stringify(processEnv)}`);

--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -146,15 +146,12 @@ export async function runPulumi() {
             return;
         }
 
-        // Get the working directory where the Pulumi commands must be run.
-        const pathEnv = process.env["PATH"];
-        tl.debug(`Executing Pulumi commands with PATH ${pathEnv}`);
-        const pulCwd = tl.getInput("cwd") || ".";
-
+        const processEnv = process.env as IEnvMap;
+        tl.debug(`Executing Pulumi commands with process env ${JSON.stringify(processEnv)}`);
         const envVars: IEnvMap = {
             ...azureServiceEndpointEnvVars,
             ...agentEnvVars,
-            PATH: pathEnv || "",
+            ...processEnv,
         };
 
         // For DotNet projects, the dotnet CLI requires a home directory (sort of a temp directory).
@@ -166,6 +163,8 @@ export async function runPulumi() {
             tl.getVariable("Agent.TempDirectory") ||
             "";
         envVars["DOTNET_CLI_HOME"] = dotnetCliHome;
+        // Get the working directory where the Pulumi commands must be run.
+        const pulCwd = tl.getInput("cwd") || ".";
         const pulExecOptions = getExecOptions(envVars, pulCwd);
 
         // Select the stack.

--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -88,8 +88,8 @@ function tryGetAzureEnvVarsFromServiceEndpoint(): IEnvMap {
  */
 function tryGetEnvVars(): IEnvMap {
     const vars: IEnvMap = {};
-    tl.getVariables().forEach((varInfo) => {
-        vars[varInfo.name] = varInfo.value;
+    tl.getVariables().forEach((vi) => {
+        vars[vi.name] = vi.value;
     });
 
     return vars;
@@ -146,6 +146,10 @@ export async function runPulumi() {
             return;
         }
 
+        /**
+         * `process.env` only contains "public" variables, i.e. system and agent variables that
+         * are not secret. Secret vars can only be retrieved using `tl.getVariable` or `tl.getVariables`.
+         */
         const processEnv = process.env as IEnvMap;
         tl.debug(`Executing Pulumi commands with process env ${JSON.stringify(processEnv)}`);
         const envVars: IEnvMap = {
@@ -154,9 +158,11 @@ export async function runPulumi() {
             ...processEnv,
         };
 
-        // For DotNet projects, the dotnet CLI requires a home directory (sort of a temp directory).
-        // On Azure Pipelines, the user home env var is undefined, and the workaround is to
-        // set the DOTNET_CLI_HOME env var. This is not a Pulumi-specfic env var.
+        /**
+         * For DotNet projects, the dotnet CLI requires a home directory (sort of a temp directory).
+         * On Azure Pipelines, the user home env var is undefined, and the workaround is to
+         * set the DOTNET_CLI_HOME env var. This is not a Pulumi-specfic env var.
+         */
         const dotnetCliHome =
             tl.getVariable("dotnet.cli.home") ||
             tl.getVariable("DOTNET_CLI_HOME") ||


### PR DESCRIPTION
This PR adds the `process.env` map to the tool runner's exec options, so that all built-in system and agent variables are available to the Pulumi CLI as an env var in the format that it expects (i.e., upper-cased, spaces and dots replaces with `_`.)