### PR TITLE
Check if loginArgs are passed before failing the task

### DIFF
--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -115,7 +115,7 @@ export async function runPulumi() {
         };
 
         const azureStorageContainer = agentEnvVars["AZURE_STORAGE_CONTAINER"];
-
+        const loginArgs = tl.getDelimitedInput("loginArgs", " ");
         // Login and then run the command.
         tl.debug(tl.loc("Debug_Login"));
         // For backward compatibility, also check for `pulumi.access.token`
@@ -125,7 +125,7 @@ export async function runPulumi() {
             // `getVariable` will automatically prepend the SECRET_ prefix if it finds
             // it in the build environment's secret vault.
             tl.getVariable("PULUMI_ACCESS_TOKEN");
-        if (!azureStorageContainer && !pulumiAccessToken) {
+        if (!azureStorageContainer && !pulumiAccessToken && loginArgs.length === 0) {
             tl.setResult(tl.TaskResult.Failed, tl.loc("PulumiLoginUndetermined"));
             return;
         }
@@ -137,7 +137,6 @@ export async function runPulumi() {
             loginEnvVars[PULUMI_ACCESS_TOKEN] = pulumiAccessToken;
         }
 
-        const loginArgs = tl.getDelimitedInput("loginArgs", " ");
         let loginCmdRunner = tl.tool(toolPath).arg(loginCommand);
         loginCmdRunner = appendArgsToToolCmd(loginCmdRunner, loginArgs);
         const exitCode = await loginCmdRunner.exec(getExecOptions(loginEnvVars, ""));

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -101,7 +101,7 @@
         "PulumiNotFound": "Pulumi CLI does not seem to be installed in your environment.",
         "PulumiCommandFailed": "Pulumi command exited with code '%s' while trying to run '%s'.",
         "PulumiStackSelectFailed": "Failed to select the stack '%s'.",
-        "PulumiLoginUndetermined": "Couldn't determine which login method to use. This task extension supports Pulumi Service backend and self-managed backend using Azure Storage. Learn more at https://www.pulumi.com/docs/intro/concepts/state.",
+        "PulumiLoginUndetermined": "Couldn't determine which login method to use. This task extension supports Pulumi Service backend and self-managed backends. Learn more at https://www.pulumi.com/docs/intro/concepts/state.",
         "DetectedVersion": "%s variable detected with value '%s'. Task will use this version from the local tool cache.",
         "Debug_NotFoundInCache": "Pulumi not found in the local tool cache. Will download and install it.",
         "Debug_Starting": "Starting..",


### PR DESCRIPTION
We check if the user has supplied at least one form of logging in to the Pulumi CLI, and that check wasn't accounting for the newly-added `loginArgs` task input variable. This PR fixes that.