### PR TITLE
Allow users to indicate if a stack should be created, if it does not exist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 Thank you for contributing! Before submitting your PR, can you please confirm that you have done the following?
 
-* [ ] If you changed the values of the properties `name`, `author`, and `galleryFlags` in the `vss-extension.json` file, you have reverted them.
+* [ ] If you changed the values of the properties `name`, `publisher`, and `galleryFlags` in the `vss-extension.json` file, you have reverted them.
 * [ ] If you changed the values of the properties `id`, `name`, `author`, you have reverted them.
 * [ ] I have reverted any changes to the version number components in both `vss-extension.json` and `task.json`, OR I didn't change them.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Thank you for contributing! Before submitting your PR, can you please confirm that you have done the following?
+
+* [ ] If you changed the values of the properties `name`, `author`, and `galleryFlags` in the `vss-extension.json` file, you have reverted them.
+* [ ] If you changed the values of the properties `id`, `name`, `author`, you have reverted them.
+* [ ] I have reverted any changes to the version number components in both `vss-extension.json` and `task.json`, OR I didn't change them.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ If you wish to enable detailed traces, also set `TASK_TEST_TRACE=1` before runni
 
 On Windows, you can do this using `$env:TASK_TEST_TRACE=1`.
 
+### Testing in your own DevOps Organization
+
+Sometimes unit testing alone isn't sufficient and you may want to test your changes in a real Azure DevOps organization. To do so, however, you will need to change some values in the manifest files so that you can run `npm run package` to create a VSIX package that you can install privately into your own organization. Follow these steps:
+
+#### Prerequisites
+
+- Signup for a free [Azure DevOps organization](https://azure.microsoft.com/en-us/services/devops/).
+- Once you have created a new organization, you will need a Visual Studio Marketplace publisher account to install the extension into your newly-created organization. Click [here](https://marketplace.visualstudio.com/manage/createpublisher) to create a new publisher account.
+- Now that you have created your publisher account, you are now ready to make necessary changes to the manifest files to create a private package that you can publish using your new publisher account to your own organization.
+
+#### Updating the manifest files
+
+- In the `vss-extension.json` file, modify the value of the `name` property to something unique.
+- Change the value of the property `galleryFlags` to `Private` instead of `Public`.
+  - Tip: Maybe give it a suffix or a prefix that clearly identifies it as your private build.
+- Now in the `buildAndReleaseTask/task.json`, change the value of the `id` property to a unique value. You can get a new, unique value from https://www.guidgen.com.
+- Change the value of the `name` property to something unique in this file as well.
+  - This is the name you will see in the Azure Pipelines build when you add it as a task.
+- **IMPORTANT!** Change the value of the `author` property to be _your_ new publisher account username.
+
 ## Package
 
 > Learn more [here](https://docs.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?view=azure-devops#step-4-package-your-extension).

--- a/README.md
+++ b/README.md
@@ -49,16 +49,46 @@ Sometimes unit testing alone isn't sufficient and you may want to test your chan
 - Signup for a free [Azure DevOps organization](https://azure.microsoft.com/en-us/services/devops/).
 - Once you have created a new organization, you will need a Visual Studio Marketplace publisher account to install the extension into your newly-created organization. Click [here](https://marketplace.visualstudio.com/manage/createpublisher) to create a new publisher account.
 - Now that you have created your publisher account, you are now ready to make necessary changes to the manifest files to create a private package that you can publish using your new publisher account to your own organization.
+- To manage your new publisher account, you can visit `https://marketplace.visualstudio.com/manage/publishers/{your_publisher_account_name}`.
 
 #### Updating the manifest files
 
 - In the `vss-extension.json` file, modify the value of the `name` property to something unique.
-- Change the value of the property `galleryFlags` to `Private` instead of `Public`.
+- **IMPORTANT:** Change the value of the property `galleryFlags` to `Private` instead of `Public`.
   - Tip: Maybe give it a suffix or a prefix that clearly identifies it as your private build.
 - Now in the `buildAndReleaseTask/task.json`, change the value of the `id` property to a unique value. You can get a new, unique value from https://www.guidgen.com.
 - Change the value of the `name` property to something unique in this file as well.
   - This is the name you will see in the Azure Pipelines build when you add it as a task.
-- **IMPORTANT!** Change the value of the `author` property to be _your_ new publisher account username.
+- **IMPORTANT:** Change the value of the `author` property to be _your_ new publisher account name.
+
+#### Generate a private package
+
+- From the root of the project directory, run `npm run package`. This will bump the version number and produce a new package with the `.vsix` file extension.
+- Go to your publisher account page, `https://marketplace.visualstudio.com/manage/publishers/{your_publisher_account_name}` (be sure to replace `{your_publisher_account_name}` with the actual value), and click on **New Extension** > **Azure DevOps** and drag/drop the VSIX file you generated in the previous step.
+- Follow the on-screen instructions (if any). Now you are ready to share the private build with your organization.
+
+#### Share the private build with your organization
+
+- Once the package upload is complete, you can click on the options icon (the `...` button) and click on **Share/Unshare**.
+- Click on **+ Organization** to add your newly-created DevOps organization.
+
+#### Installing the private build
+
+- Finally, you can now head over to your organization and install the extension that has been shared with it.
+- Go to the root of your organization, `https://dev.azure.com`, and click on the **Organization Settings** button in the bottom-left corner.
+- Then click on **Extensions** and then click on the **Shared** tab. You should see your private extension.
+- Click on the install button and follow the instructions to complete installing it.
+
+Once installed, return to your organization and create a new Azure Pipelines build and you should now see the newly installed private build of the task extension.
+
+#### Uploading new versions of the private build
+
+- To continue testing your private build of the task extension, you can simply run `npm run package` in the root of this project, and then upload a new build to your publisher account.
+- Once uploaded, any Azure Pipelines build agents using it will automatically pick up the new version in a few minutes.
+
+#### Completing your testing
+
+- Once your testing is complete, you must revert the changes you made to the `vss-extension.json` and `task.json` as part of generating your private build. However, any other changes you made to those files, that is relevant to any Pull Request you decide to submit can remain intact.
 
 ## Package
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ Sometimes unit testing alone isn't sufficient and you may want to test your chan
 #### Updating the manifest files
 
 - In the `vss-extension.json` file, modify the value of the `name` property to something unique.
-- **IMPORTANT:** Change the value of the property `galleryFlags` to `Private` instead of `Public`.
   - Tip: Maybe give it a suffix or a prefix that clearly identifies it as your private build.
+- **IMPORTANT:** Change the value of the following properties:
+  - Set `galleryFlags` to `Private` instead of `Public`.
+  - Set `publisher` to _your_ publisher account name instead of `pulumi`.
 - Now in the `buildAndReleaseTask/task.json`, change the value of the `id` property to a unique value. You can get a new, unique value from https://www.guidgen.com.
 - Change the value of the `name` property to something unique in this file as well.
   - This is the name you will see in the Azure Pipelines build when you add it as a task.
-- **IMPORTANT:** Change the value of the `author` property to be _your_ new publisher account name.
+- **IMPORTANT:** Change the value of the `author` property to be _your_ publisher account name.
 
 #### Generate a private package
 

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -15,9 +15,14 @@
         "Minor": 0,
         "Patch": 5
     },
+    "releaseNotes": "Added the Advanced Options category.",
+    "groups": [{
+        "name": "advanced",
+        "displayName": "Advanced Options",
+        "isExpanded": true
+    }],
     "instanceNameFormat": "Run pulumi $(pulCommand) $(pulArgs)",
-    "inputs": [
-        {
+    "inputs": [{
             "name": "azureSubscription",
             "type": "connectedService:AzureRM",
             "label": "Azure Subscription",
@@ -43,14 +48,6 @@
                 "preview": "preview",
                 "destroy": "destroy"
             }
-        },
-        {
-            "name": "createStack",
-            "type": "boolean",
-            "label": "Create the stack if it does not exist",
-            "defaultValue": "false",
-            "helpMarkDown": "Check this option if you would like this task to create the stack, only if it does not exist already.",
-            "required": "false"
         },
         {
             "name": "loginArgs",
@@ -90,6 +87,15 @@
             "label": "Pulumi version",
             "defaultValue": "latest",
             "helpMarkDown": "The Pulumi version that should be used. If you require a specific version then the format is `1.5.0` or if you just need the latest version then `latest` can be used.",
+            "required": "false"
+        },
+        {
+            "name": "createStack",
+            "type": "boolean",
+            "label": "Create the stack if it does not exist",
+            "defaultValue": "false",
+            "groupName": "advanced",
+            "helpMarkDown": "Check this option if you would like this task to create the Pulumi stack, only if it does not exist already.",
             "required": "false"
         }
     ],

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -37,13 +37,20 @@
             },
             "options": {
                 "new": "new",
-                "init": "init",
                 "stack": "stack",
                 "config": "config",
                 "up": "up",
                 "preview": "preview",
                 "destroy": "destroy"
             }
+        },
+        {
+            "name": "createStack",
+            "type": "boolean",
+            "label": "Create the stack if it does not exist",
+            "defaultValue": "false",
+            "helpMarkDown": "Check this option if you would like this task to create the stack, only if it does not exist already.",
+            "required": "false"
         },
         {
             "name": "loginArgs",
@@ -103,6 +110,7 @@
         "PulumiStackSelectFailed": "Failed to select the stack '%s'.",
         "PulumiLoginUndetermined": "Couldn't determine which login method to use. This task extension supports Pulumi Service backend and self-managed backends. Learn more at https://www.pulumi.com/docs/intro/concepts/state.",
         "DetectedVersion": "%s variable detected with value '%s'. Task will use this version from the local tool cache.",
+        "CreateStackFailed": "Failed to create the stack '%s'.",
         "Debug_NotFoundInCache": "Pulumi not found in the local tool cache. Will download and install it.",
         "Debug_Starting": "Starting..",
         "Debug_AddedToPATH": "Added Pulumi to PATH.",
@@ -114,6 +122,7 @@
         "Debug_TempDirectoryNotSet": "agent.tempdirectory not set. Using $HOME/temp.",
         "Debug_LatestPulumiVersion": "Latest pulumi version is '%s'.",
         "Debug_CachingPulumiToHome": "Caching pulumi CLI to path '%s'.",
-        "Debug_ExpectedPulumiVersion": "Requested Pulumi version is '%s'."
+        "Debug_ExpectedPulumiVersion": "Requested Pulumi version is '%s'.",
+        "Debug_CreateStack": "Stack '%s' was not found. Creating it..."
     }
 }

--- a/buildAndReleaseTask/tests/_suite.ts
+++ b/buildAndReleaseTask/tests/_suite.ts
@@ -3,50 +3,67 @@
 import * as assert from "assert";
 import * as ttm from "azure-pipelines-task-lib/mock-test";
 import * as path from "path";
-import { userRequestedVersion } from "./success";
+
+function mustNotHaveErrorsOrWarnings(tr: ttm.MockTestRunner) {
+    assert.equal(tr.succeeded, true, "should have succeeded");
+    assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+    assert.equal(tr.errorIssues.length, 0, "should have no errors");
+}
 
 describe("Pulumi task tests", () => {
 
     it("should install the CLI and run command", (done: MochaDone) => {
         const tp = path.join(__dirname, "success.js");
-        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        const tr = new ttm.MockTestRunner(tp);
 
         tr.run();
+        mustNotHaveErrorsOrWarnings(tr);
+        const stdout = tr.stdout;
+        // This version number should match the version number in the actual test `success.ts`.
+        // The reason we are not simply exporting the const from the test and using it here is,
+        // for some odd reason, doing so is causing the mock-test library to print debugging
+        // output always, even when not setting the `TASK_TEST_TRACE` env var before running the test.
+        const expectedVersion = "0.16.5";
+        assert.equal(stdout.indexOf(expectedVersion) >= 0, true, "should execute `pulumi version` command");
+        assert.equal(stdout.indexOf("stack selected") >= 0, true, "should select stack");
+        assert.equal(stdout.indexOf("fake logged in") >= 0, true, "should login");
+        assert.equal(stdout.indexOf("fake pulumi preview") >= 0, true, "should execute `pulumi preview` command");
 
-        assert.equal(tr.succeeded, true, "should have succeeded");
-        assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-
-        console.log("***Printing test output***");
-        assert.equal(tr.stdout.indexOf(userRequestedVersion) >= 0, true, "should execute `pulumi version` command");
-        assert.equal(tr.stdout.indexOf("stack selected") >= 0, true, "should select stack");
-        assert.equal(tr.stdout.indexOf("fake logged in") >= 0, true, "should login");
-        assert.equal(tr.stdout.indexOf("fake pulumi preview") >= 0, true, "should execute `pulumi preview` command");
         done();
     });
 
     it("should run Pulumi with the expected env vars", (done: MochaDone) => {
         const tp = path.join(__dirname, "envvars.js");
-        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        const tr = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert.equal(tr.succeeded, true, "should have succeeded");
-        assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
+        mustNotHaveErrorsOrWarnings(tr);
 
         done();
     });
 
     it("should run Pulumi with Azure Storage with the expected env vars", (done: MochaDone) => {
         const tp = path.join(__dirname, "envvars_storage.js");
-        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        const tr = new ttm.MockTestRunner(tp);
 
         tr.run();
-        assert.equal(tr.stdout.indexOf("fake logged in using azure storage") >= 0, true, "should login using azure environment variables");
-        assert.equal(tr.succeeded, true, "should have succeeded");
-        assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        
+        mustNotHaveErrorsOrWarnings(tr);
+        assert.equal(
+            tr.stdout.indexOf("fake logged in using azure storage") >= 0,
+            true,
+            "should login using azure environment variables");
+
+        done();
+    });
+
+    it("should create the stack if it does not exist", (done: MochaDone) => {
+        const tp = path.join(__dirname, "create_stack_if_not_found.js");
+        const tr = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        mustNotHaveErrorsOrWarnings(tr);
+        assert.equal(tr.stdout.indexOf("Created stack") >= 0, true, "should create stack");
+
         done();
     });
 });

--- a/buildAndReleaseTask/tests/create_stack_if_not_found.ts
+++ b/buildAndReleaseTask/tests/create_stack_if_not_found.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
 
 import * as ma from "azure-pipelines-task-lib/mock-answer";
 import * as tmrm from "azure-pipelines-task-lib/mock-run";

--- a/buildAndReleaseTask/tests/envvars.ts
+++ b/buildAndReleaseTask/tests/envvars.ts
@@ -5,7 +5,7 @@ import * as tmrm from "azure-pipelines-task-lib/mock-run";
 import * as path from "path";
 
 const taskPath = path.join(__dirname, "..", "index.js");
-const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const tmr = new tmrm.TaskMockRunner(taskPath);
 
 const fakeOS = "Linux";
 const latestPulumiVersion = "1.5.1";
@@ -22,7 +22,7 @@ tmr.setVariableName("PULUMI_ACCESS_TOKEN", "fake-access-token", true);
 tmr.setVariableName("AWS_ACCESS_KEY_ID", "fake-access-key-id", false);
 tmr.setVariableName("AWS_SECRET_ACCESS_KEY", "fake-secret-access-key", true);
 
-// Set the mock inputs for the task. These imitate actual user inputs.
+// Set the mock inputs for the task.
 tmr.setInput("command", "preview");
 tmr.setInput("cwd", "dir/");
 tmr.setInput("stack", "myOrg/project/dev");

--- a/buildAndReleaseTask/tests/success.ts
+++ b/buildAndReleaseTask/tests/success.ts
@@ -7,13 +7,13 @@ import * as path from "path";
 import { IServiceEndpoint } from "../serviceEndpoint";
 
 const taskPath = path.join(__dirname, "..", "index.js");
-const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const tmr = new tmrm.TaskMockRunner(taskPath);
 
 const fakeOS = "Linux";
 const latestPulumiVersion = "1.5.1";
 // If the user requested version is not `latest`, then this is the version
 // that the task should install.
-export const userRequestedVersion = "0.16.5";
+const userRequestedVersion = "0.16.5";
 const expectedDownloadUrl =
     `https://get.pulumi.com/releases/sdk/pulumi-v${userRequestedVersion}-${fakeOS.toLowerCase()}-x64.tar.gz`;
 const fakeDownloadedPath = "/fake/path/to/downloaded/file";
@@ -21,7 +21,7 @@ const fakeDownloadedPath = "/fake/path/to/downloaded/file";
 process.env["HOME"] = "/fake/home";
 
 tmr.setVariableName("PULUMI_ACCESS_TOKEN", "fake-access-token", true);
-// Set the mock inputs for the task. These imitate actual user inputs.
+// Set the mock inputs for the task.
 tmr.setInput("azureSubscription", "fake-subscription-id");
 tmr.setInput("command", "preview");
 tmr.setInput("cwd", "dir/");


### PR DESCRIPTION
Fixes #33. Resolves #34.

* Removed the `init` command from the pick list for the `command` input.
* Added a new group (Advanced Options; see screenshot below) to put options that are slightly beyond the average use.
* Added the `createStack` boolean task input to the advanced options group, so that a user can indicate they would like to create the stack if it does not exist already.

This is how it looks in the Azure Pipelines build configuration UI:

<img width="548" alt="Screen Shot 2020-02-05 at 10 59 55" src="https://user-images.githubusercontent.com/1466314/73873571-af85b300-4806-11ea-9ee6-6a14c0a99483.png">
