### PR TITLE
Update the versions for the DevOps Extensions management extensions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ stages:
         outputVariable: 'TestExtension.Version'
         extensionVersionOverride: 'TestExtension.VersionOverride'
 
-    - task: PackageVSTSExtension@1
+    - task: PackageAzureDevOpsExtension@3
       inputs:
         outputVariable: 'TestExtension.OutputPath'
         publisherId: 'pulumi'
@@ -103,7 +103,7 @@ stages:
         extensionVisibility: 'private'
         extensionPricing: 'free'
 
-    - task: PublishExtension@1
+    - task: PublishAzureDevOpsExtension@3
       displayName: 'Publish Extension'
       inputs:
         connectTo: 'VsTeam'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ stages:
 
     - task: TfxInstaller@2
       inputs:
-        version: 'v0.7.x'
+        version: 'v0.8.x'
 
     - task: CmdLine@2
       displayName: 'Update task name'

--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -195,7 +195,7 @@ export async function runPulumi() {
             tl.getVariable("pulumi.access.token") ||
             // `getVariable` will automatically prepend the SECRET_ prefix if it finds
             // it in the build environment's secret vault.
-            tl.getVariable("PULUMI_ACCESS_TOKEN");
+            tl.getVariable(PULUMI_ACCESS_TOKEN);
         if (!azureStorageContainer && !pulumiAccessToken && loginArgs.length === 0) {
             tl.setResult(tl.TaskResult.Failed, tl.loc("PulumiLoginUndetermined"));
             return;

--- a/package.azure-pipelines.yml
+++ b/package.azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
 
   - task: TfxInstaller@2
     inputs:
-      version: 'v0.7.x'
+      version: 'v0.8.x'
 
   - task: QueryAzureDevOpsExtensionVersion@3
     displayName: 'Query extension version'

--- a/package.azure-pipelines.yml
+++ b/package.azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
     inputs:
       version: 'v0.7.x'
 
-  - task: ExtensionVersion@1
+  - task: QueryAzureDevOpsExtensionVersion@3
     displayName: 'Query extension version'
     inputs:
       connectTo: 'VsTeam'
@@ -37,7 +37,7 @@ jobs:
       outputVariable: 'Extension.Version'
       extensionVersionOverride: 'Extension.VersionOverride'
 
-  - task: PackageVSTSExtension@1
+  - task: PackageAzureDevOpsExtension@3
     displayName: 'Package extension'
     inputs:
       extensionVersion: '$(Extension.Version)'


### PR DESCRIPTION
It appears that the version that we were using has become quite old. An issue with one of the dependencies of tfx-cli is causing an error message to be written to STDERR that fails the build. This was [fixed](https://github.com/microsoft/azure-devops-extension-tasks/pull/177) in the 3.x version of the suite of extensions that we use for querying, packaging and publishing our extension to the VS Marketplace. So this PR updates the versions that we use to the newer ones.