### PR TITLE
Change the output variable name for the packaging build

### DIFF
--- a/package.azure-pipelines.yml
+++ b/package.azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
   - task: PackageAzureDevOpsExtension@3
     displayName: 'Package extension'
     inputs:
-      extensionVersion: $(Extension.Version)
+      extensionVersion: '1.0.8'
       updateTasksVersion: true
 
   - task: PublishPipelineArtifact@0

--- a/package.azure-pipelines.yml
+++ b/package.azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
   - task: PackageAzureDevOpsExtension@3
     displayName: 'Package extension'
     inputs:
-      extensionVersion: '$(Extension.Version)'
+      extensionVersion: $(Extension.Version)
       updateTasksVersion: true
 
   - task: PublishPipelineArtifact@0

--- a/package.azure-pipelines.yml
+++ b/package.azure-pipelines.yml
@@ -34,17 +34,18 @@ jobs:
       publisherId: 'pulumi'
       extensionId: 'build-and-release-task'
       versionAction: 'Patch'
-      outputVariable: 'Extension.Version'
-      extensionVersionOverride: 'Extension.VersionOverride'
+      outputVariable: 'PulumiExtension.Version'
+      extensionVersionOverride: 'PulumiExtension.VersionOverride'
 
   - task: PackageAzureDevOpsExtension@3
     displayName: 'Package extension'
     inputs:
-      extensionVersion: '1.0.8'
+      extensionVersion: '$(PulumiExtension.Version)'
       updateTasksVersion: true
+      outputVariable: 'PulumiExtension.OutputPath'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Create pipeline artifact'
     inputs:
       artifactName: 'vsix'
-      targetPath: $(Extension.OutputPath)
+      targetPath: $(PulumiExtension.OutputPath)


### PR DESCRIPTION
For whatever reason, the new version of the `PackageAzureDevOpsExtension` that we use to create a VSIX bundle doesn't work if we use the default variable names, i.e. `Extension.Version` that the previous step `QueryAzureDevOpsExtensionVersion` sets. Weirdly enough, The `QueryAzureDevOpsExtensionVersion` step does actually set the right value. I haven't dug into what's going on, but using a different variable name does work as expected. We do something [similar](https://github.com/pulumi/pulumi-az-pipelines-task/blob/master/azure-pipelines.yml#L92) in the primary build, which is what led me to suspect that if it works there it must work here too. Anyway, I triggered a manual build for the packaging build pipeline using this branch and it passed.