### PR TITLE
Remove setting DOTNET_CLI_HOME variable

### DIFF
--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -244,15 +244,6 @@ export async function runPulumi() {
             ...processEnv,
         };
 
-        // For DotNet projects, the dotnet CLI requires a home directory (sort of a temp directory).
-        // On Azure Pipelines, the user home env var is undefined, and the workaround is to
-        // set the DOTNET_CLI_HOME env var. This is not a Pulumi-specfic env var.
-        const dotnetCliHome =
-            tl.getVariable("dotnet.cli.home") ||
-            tl.getVariable("DOTNET_CLI_HOME") ||
-            tl.getVariable("Agent.TempDirectory") ||
-            "";
-        envVars["DOTNET_CLI_HOME"] = dotnetCliHome;
         // Get the working directory where the Pulumi commands must be run.
         const pulCwd = tl.getInput("cwd") || ".";
         const pulExecOptions = getExecOptions(envVars, pulCwd);

--- a/overview.md
+++ b/overview.md
@@ -190,4 +190,19 @@ If the Azure Pipelines Agent does not have access to the service accounts home d
 error: The user's home directory could not be determined. Set the 'DOTNET_CLI_HOME' environment variable to specify the directory to use.
 ```
 
-To remediate this either allow the agent access to the home directory, or set the `DOTNET_CLI_HOME` variable. This can be done either as a pipeline variable or directly in the task using the `env` parameter.
+To remediate this either allow the agent access to the home directory, or set the `DOTNET_CLI_HOME` variable. This can be done either as a [pipeline variable](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-variables-in-pipeline) or directly in the task using the `env` parameter. An example of setting this can be found below:
+
+```yaml
+# Setting the variable for use in the job/stage
+variables:
+- name: DOTNET_CLI_HOME
+  value: $(Agent.TempDirectory)
+
+# Or Setting the variable to the agents temporary directory for this task only
+- task: Pulumi@1
+  env:
+    DOTNET_CLI_HOME: $(Agent.TempDirectory)
+  inputs:
+    command: preview
+    stack: $(StackName)
+```

--- a/overview.md
+++ b/overview.md
@@ -180,3 +180,14 @@ Try to uninstall the extension, and then re-install it. Most of the times this r
 Pulumi supports several [cloud providers](https://www.pulumi.com/docs/intro/cloud-providers/), including [Kubernetes](https://www.pulumi.com/docs/intro/cloud-providers/kubernetes/). You can deploy to any cloud provider that Pulumi supports using this task extension, by simply setting the required environment variables as part of each cloud provider's setup, as your Pipeline's build variable.
 
 For example, in order to deploy to [AWS](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/#environment-variables), simply set the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` env vars either as pipeline variables or in a variable group that is linked to your pipeline.
+
+## Troubleshooting
+
+### User's Home directory could not be determined
+If the Azure Pipelines Agent does not have access to the service accounts home directory, Pulumi projects using the dotnet runtime may be faced with the below error message when executing Pulumi commands:
+
+```
+error: The user's home directory could not be determined. Set the 'DOTNET_CLI_HOME' environment variable to specify the directory to use.
+```
+
+To remediate this either allow the agent access to the home directory, or set the `DOTNET_CLI_HOME` variable. This can be done either as a pipeline variable or directly in the task using the `env` parameter.


### PR DESCRIPTION
Remove unnecessary defaulting of DOTNET_CLI_HOME variable to allow OS to determine this behaviour.

Related to #40

Thank you for contributing! Before submitting your PR, can you please confirm that you have done the following?

* [x] If you changed the values of the properties `name`, `publisher`, and `galleryFlags` in the `vss-extension.json` file, you have reverted them.
* [x] If you changed the values of the properties `id`, `name`, `author`, you have reverted them.
* [x] I have reverted any changes to the version number components in both `vss-extension.json` and `task.json`, OR I didn't change them.
