### PR TITLE
Update cache directory and PATH to use the correct folder

### DIFF
--- a/buildAndReleaseTask/installers/pulumi.ts
+++ b/buildAndReleaseTask/installers/pulumi.ts
@@ -62,10 +62,13 @@ async function installPulumiOther(version: string, os: string) {
             `https://get.pulumi.com/releases/sdk/pulumi-v${version}-${os}-x64.tar.gz`;
         const temp = await lib.downloadTool(downloadUrl);
         const extractTemp = await lib.extractTar(temp);
-        lib.prependPath(path.join(extractTemp, "pulumi"));
+        // Pulumi binary exists in "pulumi" sub-folder,
+        // so use this folder to prepend to path and cache
+        const binPath = path.join(extractTemp, "pulumi");
+        lib.prependPath(binPath);
         tl.debug(tl.loc("Debug_Installed"));
         tl.debug(tl.loc("Debug_AddedToPATH"));
-        await lib.cacheDir(extractTemp, "pulumi", version);
+        await lib.cacheDir(binPath, "pulumi", version);
     } catch (err) {
         tl.setResult(tl.TaskResult.Failed, tl.loc("PulumiInstallFailed", err.message), true);
     }


### PR DESCRIPTION
Fixes #64 

Sets the correct folder to prepend to path and cache in the tool path as the Pulumi binary exists in a `pulumi` sub-folder in the extracted tar.gz, similar to Windows

Thank you for contributing! Before submitting your PR, can you please confirm that you have done the following?

* [x] If you changed the values of the properties `name`, `publisher`, and `galleryFlags` in the `vss-extension.json` file, you have reverted them.
* [x] If you changed the values of the properties `id`, `name`, `author`, you have reverted them.
* [x] I have reverted any changes to the version number components in both `vss-extension.json` and `task.json`, OR I didn't change them.
