### PR TITLE
Fix job name to not have dashes

### DIFF
--- a/integrationtest.azure-pipelines.yml
+++ b/integrationtest.azure-pipelines.yml
@@ -10,6 +10,7 @@ trigger: none
 
 jobs:
   - job: aws
+    displayName: AWS
     pool:
       vmImage: "ubuntu-latest"
     steps:
@@ -33,6 +34,7 @@ jobs:
           stack: "$(Example.AWS.StackName)"
 
   - job: azure
+    displayName: Azure
     pool:
       vmImage: "ubuntu-latest"
     steps:
@@ -57,7 +59,8 @@ jobs:
           cwd: "./examples/azure"
           stack: "$(Example.Azure.StackName)"
 
-  - job: azure-native-dotnet
+  - job: azure_native_dotnet
+    displayName: "Azure Native DotNet"
     pool:
       vmImage: "ubuntu-latest"
     steps:


### PR DESCRIPTION
Unfortunately the previous PR failed after merging due to the integration test pipeline config containing an invalid job name.