### PR TITLE
script tasks need to get env vars explicitly mapped

### DIFF
--- a/integrationtest.azure-pipelines.yml
+++ b/integrationtest.azure-pipelines.yml
@@ -51,6 +51,8 @@ jobs:
           pulumi config set azure:location WestUS
         displayName: "Set azure config for examples/azure"
         workingDirectory: "./examples/azure"
+        env:
+          PULUMI_ACCESS_TOKEN: $(PULUMI_ACCESS_TOKEN)
 
       - task: Test Pulumi@1
         inputs:
@@ -74,6 +76,8 @@ jobs:
           pulumi config set azure:location WestUS
         displayName: "Set azure config for examples/azure-dotnet"
         workingDirectory: "./examples/azure-native-dotnet"
+        env:
+          PULUMI_ACCESS_TOKEN: $(PULUMI_ACCESS_TOKEN)
 
       - task: Test Pulumi@1
         inputs:

--- a/integrationtest.azure-pipelines.yml
+++ b/integrationtest.azure-pipelines.yml
@@ -47,6 +47,7 @@ jobs:
         displayName: "Install Pulumi"
 
       - script: |
+          pulumi stack select ${EXAMPLE_AZURE_STACKNAME}
           pulumi config set azure:environment public
           pulumi config set azure:location WestUS
         displayName: "Set azure config for examples/azure"
@@ -72,6 +73,7 @@ jobs:
         displayName: "Install Pulumi"
 
       - script: |
+          pulumi stack select ${EXAMPLE_AZURENATIVEDOTNET_STACKNAME}
           pulumi config set azure:environment public
           pulumi config set azure:location WestUS
         displayName: "Set azure config for examples/azure-dotnet"

--- a/integrationtest.azure-pipelines.yml
+++ b/integrationtest.azure-pipelines.yml
@@ -74,8 +74,8 @@ jobs:
 
       - script: |
           pulumi stack select ${EXAMPLE_AZURENATIVEDOTNET_STACKNAME}
-          pulumi config set azure:environment public
-          pulumi config set azure:location WestUS
+          pulumi config set azure-native:environment public
+          pulumi config set azure-native:location WestUS
         displayName: "Set azure config for examples/azure-dotnet"
         workingDirectory: "./examples/azure-native-dotnet"
         env:


### PR DESCRIPTION
This one was a surprise to me. That the CLI needs to login in order to set a plaintext stack config. If I was setting a secret, I can understand the need for the access token due to the stack using service-managed secrets. Anyway, is that intended behavior of the CLI? To fix this I have now explicitly mapped the access token for the `script` step since it is a secret. Secret vars need to be explicitly mapped to `script` steps.