### PR TITLE
Migrate task to Node10 runtime

### DIFF
--- a/buildAndReleaseTask/package-lock.json
+++ b/buildAndReleaseTask/package-lock.json
@@ -108,17 +108,17 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.0.tgz",
-      "integrity": "sha512-9L+uG3dxwr/orjFy8tWa2fti+2weiRAdsKVtXINfIpLKFSAHS9tKOpupS53CgBJzQxFf5HfZwNeiUTv+/dBPpA==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.10.tgz",
+      "integrity": "sha512-S5iH1mD9G7boOV0kjVsFkqlz/6FOZjQAajshj3ajzQK9Wr3XRq9JK9+grJP4ityG6of28X2XWpieFdJLhnWLoA==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "^1.7.0",
@@ -301,9 +301,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "form-data": {
       "version": "2.5.1",

--- a/buildAndReleaseTask/package.json
+++ b/buildAndReleaseTask/package.json
@@ -12,8 +12,8 @@
   "author": "Pulumi",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.21.1",
-    "azure-pipelines-task-lib": "^3.1.0",
+    "axios": "^0.21.4",
+    "azure-pipelines-task-lib": "^3.1.10",
     "azure-pipelines-tool-lib": "^1.0.1",
     "semver": "^7.3.4",
     "typed-rest-client": "^1.8.4"

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -104,7 +104,7 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node10": {
             "target": "index.js"
         }
     },


### PR DESCRIPTION
Fixes #84.

The task thankfully does not depend on anything specific to legacy Node versions. To provide some background, when the task was authored it's just that the tutorials for creating a custom task extension used the execution target as `Node` instead of `Node10`. I am not even sure if Azure Pipelines had support for Node10+ execution targets back when this was originally authored.

I followed the guide from https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode10.md.