### PR TITLE
Set the job pool explicitly for the test packaging stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ stages:
   jobs:
   - job: build
     pool:
-      vmImage: 'Ubuntu-latest'
+      vmImage: 'ubuntu-latest'
     steps:
     - task: NodeTool@0
       inputs:
@@ -50,6 +50,8 @@ stages:
   jobs:
   - job: testTfxCreate
     displayName: 'Create and publish test extension'
+    pool:
+      vmImage: 'ubuntu-latest'
     steps:
     - task: Npm@1
       displayName: 'Restore node_modules for buildAndReleaseTask/'


### PR DESCRIPTION
The stage that builds/publishes a test version of the task extension for integration test purposes is being skipped because Az Pipelines service is failing to find an agent with the following error:

```
##[warning]An image label with the label Ubuntu16 does not exist.
,##[error]The remote provider was unable to process the request.
Pool: Azure Pipelines
Image: Ubuntu16
```

It looks like the agent pool image is defaulting to an old version of ubuntu that perhaps no longer is in service in Az Pipelines? In any case, this PR sets the pool image for the relevant stage similar to the other ones in the pipelines.