### PR TITLE
Run lint as part of CI

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,10 +4,3 @@ package*.json
 
 **/task.json
 vss-extension.json
-
-# Temporarily ignore the following files to reduce the number of changes.
-# Will remove in a follow-up PR.
-*.ts
-azure-pipelines.yml
-integrationtest.azure-pipelines.yml
-package.azure-pipelines.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,120 +4,119 @@
 # under the pulumi publisher ID.
 
 trigger:
-- master
+  - master
 
 stages:
-- stage: build
-  displayName: 'Build and test'
-  jobs:
-  - job: build
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '12.x'
-      displayName: 'Install Node.js'
+  - stage: build
+    displayName: "Build and test"
+    jobs:
+      - job: build
+        pool:
+          vmImage: "ubuntu-latest"
+        steps:
+          - task: NodeTool@0
+            inputs:
+              versionSpec: "12.x"
+            displayName: "Install Node.js"
 
-    - task: Npm@1
-      displayName: 'Restore node_modules for buildAndReleaseTask/'
-      inputs:
-        workingDir: buildAndReleaseTask/
-        verbose: true
+          - task: Npm@1
+            displayName: "Restore node_modules for buildAndReleaseTask/"
+            inputs:
+              workingDir: buildAndReleaseTask/
+              verbose: true
 
-    - task: Npm@1
-      displayName: 'Restore node_modules for buildAndReleaseTask/tests/'
-      inputs:
-        workingDir: buildAndReleaseTask/tests
-        verbose: true
+          - task: Npm@1
+            displayName: "Restore node_modules for buildAndReleaseTask/tests/"
+            inputs:
+              workingDir: buildAndReleaseTask/tests
+              verbose: true
 
-    - task: Npm@1
-      displayName: 'Run unit tests'
-      inputs:
-        command: 'custom'
-        customCommand: run test
-      env:
-        INPUT_AZURESUBSCRIPTION: 'fake-subscription-id'
+          - task: Npm@1
+            displayName: "Run unit tests"
+            inputs:
+              command: "custom"
+              customCommand: run test
+            env:
+              INPUT_AZURESUBSCRIPTION: "fake-subscription-id"
 
-- stage: package
-  condition:
-    or(
+  - stage: package
+    condition: or(
       eq(variables['Build.Reason'], 'IndividualCI'),
       eq(variables['Build.Reason'], 'BatchedCI'),
       eq(variables['ManualOverride'], 'true')
-    )
-  displayName: 'Publish test extension'
-  jobs:
-  - job: testTfxCreate
-    displayName: 'Create and publish test extension'
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-    - task: Npm@1
-      displayName: 'Restore node_modules for buildAndReleaseTask/'
-      inputs:
-        workingDir: buildAndReleaseTask/
-        verbose: true
+      )
+    displayName: "Publish test extension"
+    jobs:
+      - job: testTfxCreate
+        displayName: "Create and publish test extension"
+        pool:
+          vmImage: "ubuntu-latest"
+        steps:
+          - task: Npm@1
+            displayName: "Restore node_modules for buildAndReleaseTask/"
+            inputs:
+              workingDir: buildAndReleaseTask/
+              verbose: true
 
-    - task: Npm@1
-      displayName: 'Compile TS to JS'
-      inputs:
-        workingDir: buildAndReleaseTask/
-        command: 'custom'
-        customCommand: run tsc
+          - task: Npm@1
+            displayName: "Compile TS to JS"
+            inputs:
+              workingDir: buildAndReleaseTask/
+              command: "custom"
+              customCommand: run tsc
 
-    - task: TfxInstaller@2
-      inputs:
-        version: 'v0.8.x'
+          - task: TfxInstaller@2
+            inputs:
+              version: "v0.8.x"
 
-    - task: CmdLine@2
-      displayName: 'Update task name'
-      inputs:
-        script: 'sed -i ''s/"Pulumi"/"Test Pulumi"/g'' task.json'
-        workingDirectory: './buildAndReleaseTask/'
-        failOnStderr: true
+          - task: CmdLine@2
+            displayName: "Update task name"
+            inputs:
+              script: 'sed -i ''s/"Pulumi"/"Test Pulumi"/g'' task.json'
+              workingDirectory: "./buildAndReleaseTask/"
+              failOnStderr: true
 
-    - task: CmdLine@2
-      displayName: 'Update task id'
-      inputs:
-        script: 'sed -i ''s/"66148448-e174-4167-91a4-0ac63f4a10ca"/"f7c2cffd-7ad2-4db6-b699-205f9e99837c"/g'' task.json'
-        workingDirectory: './buildAndReleaseTask/'
-        failOnStderr: true
+          - task: CmdLine@2
+            displayName: "Update task id"
+            inputs:
+              script: 'sed -i ''s/"66148448-e174-4167-91a4-0ac63f4a10ca"/"f7c2cffd-7ad2-4db6-b699-205f9e99837c"/g'' task.json'
+              workingDirectory: "./buildAndReleaseTask/"
+              failOnStderr: true
 
-    - task: QueryAzureDevOpsExtensionVersion@2
-      inputs:
-        connectTo: 'VsTeam'
-        connectedServiceName: 'Pulumi Marketplace'
-        publisherId: 'pulumi'
-        extensionId: 'build-and-release-task'
-        versionAction: 'Patch'
-        outputVariable: 'TestExtension.Version'
-        extensionVersionOverride: 'TestExtension.VersionOverride'
+          - task: QueryAzureDevOpsExtensionVersion@2
+            inputs:
+              connectTo: "VsTeam"
+              connectedServiceName: "Pulumi Marketplace"
+              publisherId: "pulumi"
+              extensionId: "build-and-release-task"
+              versionAction: "Patch"
+              outputVariable: "TestExtension.Version"
+              extensionVersionOverride: "TestExtension.VersionOverride"
 
-    - task: PackageAzureDevOpsExtension@3
-      inputs:
-        outputVariable: 'TestExtension.OutputPath'
-        publisherId: 'pulumi'
-        extensionId: 'test-build-and-release-task'
-        extensionName: '(Test) Pulumi Azure Pipelines Task'
-        extensionVersion: '$(TestExtension.Version).$(Build.BuildId)'
-        updateTasksVersion: true
-        extensionVisibility: 'private'
-        extensionPricing: 'free'
+          - task: PackageAzureDevOpsExtension@3
+            inputs:
+              outputVariable: "TestExtension.OutputPath"
+              publisherId: "pulumi"
+              extensionId: "test-build-and-release-task"
+              extensionName: "(Test) Pulumi Azure Pipelines Task"
+              extensionVersion: "$(TestExtension.Version).$(Build.BuildId)"
+              updateTasksVersion: true
+              extensionVisibility: "private"
+              extensionPricing: "free"
 
-    - task: PublishAzureDevOpsExtension@3
-      displayName: 'Publish Extension'
-      inputs:
-        connectTo: 'VsTeam'
-        connectedServiceName: 'Pulumi Marketplace'
-        fileType: 'vsix'
-        vsixFile: '$(TestExtension.OutputPath)'
-        publisherId: 'pulumi'
-        updateTasksVersion: false
+          - task: PublishAzureDevOpsExtension@3
+            displayName: "Publish Extension"
+            inputs:
+              connectTo: "VsTeam"
+              connectedServiceName: "Pulumi Marketplace"
+              fileType: "vsix"
+              vsixFile: "$(TestExtension.OutputPath)"
+              publisherId: "pulumi"
+              updateTasksVersion: false
 
-    - task: PublishPipelineArtifact@1
-      displayName: 'Create pipeline artifact'
-      inputs:
-        targetPath: '$(TestExtension.OutputPath)'
-        artifact: 'testvsix'
-        publishLocation: 'pipeline'
+          - task: PublishPipelineArtifact@1
+            displayName: "Create pipeline artifact"
+            inputs:
+              targetPath: "$(TestExtension.OutputPath)"
+              artifact: "testvsix"
+              publishLocation: "pipeline"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,6 @@ stages:
             inputs:
               command: "custom"
               customCommand: run lint
-            env:
-              INPUT_AZURESUBSCRIPTION: "fake-subscription-id"
 
           - task: Npm@1
             displayName: "Run unit tests"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,14 @@ stages:
             displayName: "Run unit tests"
             inputs:
               command: "custom"
+              customCommand: run lint
+            env:
+              INPUT_AZURESUBSCRIPTION: "fake-subscription-id"
+
+          - task: Npm@1
+            displayName: "Run unit tests"
+            inputs:
+              command: "custom"
               customCommand: run test
             env:
               INPUT_AZURESUBSCRIPTION: "fake-subscription-id"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ stages:
               verbose: true
 
           - task: Npm@1
-            displayName: "Run unit tests"
+            displayName: "Run lints"
             inputs:
               command: "custom"
               customCommand: run lint

--- a/buildAndReleaseTask/installers/pulumi.ts
+++ b/buildAndReleaseTask/installers/pulumi.ts
@@ -53,7 +53,7 @@ async function installPulumiWindows(version: string) {
         tl.debug(tl.loc("Debug_Installed"));
         tl.debug(tl.loc("Debug_AddedToPATH"));
         await lib.cacheDir(binPath, "pulumi", version);
-    } catch (err) {
+    } catch (err: any) {
         tl.setResult(
             tl.TaskResult.Failed,
             tl.loc("PulumiInstallFailed", err.message),
@@ -74,7 +74,7 @@ async function installPulumiOther(version: string, os: string) {
         tl.debug(tl.loc("Debug_Installed"));
         tl.debug(tl.loc("Debug_AddedToPATH"));
         await lib.cacheDir(binPath, "pulumi", version);
-    } catch (err) {
+    } catch (err: any) {
         tl.setResult(
             tl.TaskResult.Failed,
             tl.loc("PulumiInstallFailed", err.message),

--- a/buildAndReleaseTask/installers/pulumi.ts
+++ b/buildAndReleaseTask/installers/pulumi.ts
@@ -12,7 +12,10 @@ import * as path from "path";
  * @param latestPulumiVersion latest version based on what `getLatestPulumiVersion` returned.
  */
 
-export async function installPulumi(latestPulumiVersion: string, versionSpec?: string): Promise<string> {
+export async function installPulumi(
+    latestPulumiVersion: string,
+    versionSpec?: string
+): Promise<string> {
     const os = tl.getPlatform();
     tl.debug(tl.loc("OSDETECTED", os));
 
@@ -40,8 +43,7 @@ export async function installPulumi(latestPulumiVersion: string, versionSpec?: s
 
 async function installPulumiWindows(version: string) {
     try {
-        const downloadUrl =
-            `https://get.pulumi.com/releases/sdk/pulumi-v${version}-windows-x64.zip`;
+        const downloadUrl = `https://get.pulumi.com/releases/sdk/pulumi-v${version}-windows-x64.zip`;
         const temp = await lib.downloadTool(downloadUrl);
         const extractTemp = await lib.extractZip(temp);
         // Windows archives have a sub-folder called "bin", so add that
@@ -52,14 +54,17 @@ async function installPulumiWindows(version: string) {
         tl.debug(tl.loc("Debug_AddedToPATH"));
         await lib.cacheDir(binPath, "pulumi", version);
     } catch (err) {
-        tl.setResult(tl.TaskResult.Failed, tl.loc("PulumiInstallFailed", err.message), true);
+        tl.setResult(
+            tl.TaskResult.Failed,
+            tl.loc("PulumiInstallFailed", err.message),
+            true
+        );
     }
 }
 
 async function installPulumiOther(version: string, os: string) {
     try {
-        const downloadUrl =
-            `https://get.pulumi.com/releases/sdk/pulumi-v${version}-${os}-x64.tar.gz`;
+        const downloadUrl = `https://get.pulumi.com/releases/sdk/pulumi-v${version}-${os}-x64.tar.gz`;
         const temp = await lib.downloadTool(downloadUrl);
         const extractTemp = await lib.extractTar(temp);
         // Pulumi binary exists in "pulumi" sub-folder,
@@ -70,6 +75,10 @@ async function installPulumiOther(version: string, os: string) {
         tl.debug(tl.loc("Debug_AddedToPATH"));
         await lib.cacheDir(binPath, "pulumi", version);
     } catch (err) {
-        tl.setResult(tl.TaskResult.Failed, tl.loc("PulumiInstallFailed", err.message), true);
+        tl.setResult(
+            tl.TaskResult.Failed,
+            tl.loc("PulumiInstallFailed", err.message),
+            true
+        );
     }
 }

--- a/buildAndReleaseTask/models.d.ts
+++ b/buildAndReleaseTask/models.d.ts
@@ -1,0 +1,25 @@
+declare module "models" {
+    /**
+     * Represents this task's inputs as modeled in the task
+     * manifest file `task.json`.
+     */
+    export interface TaskConfig {
+        // Inputs that are not strictly required
+        // task should be marked as optional here.
+        // But if a certain input is required because
+        // a dependent input was provided, you should
+        // still mark the input as optional here
+        // and assert the value at the place of
+        // its use.
+        azureSubscription?: string;
+        command?: string;
+        loginArgs?: string;
+        args?: string;
+        cwd?: string;
+        stack?: string;
+        versionSpec?: string;
+        createStack?: boolean;
+        createPrComment?: boolean;
+        useThreadedPrComments?: boolean;
+    }
+}

--- a/buildAndReleaseTask/package.json
+++ b/buildAndReleaseTask/package.json
@@ -4,9 +4,9 @@
   "description": "Azure Pipelines task extension for running Pulumi apps.",
   "main": "index.js",
   "scripts": {
-    "test": "tsc && yarn --cwd tests/ run test",
+    "test": "tsc && npm --prefix tests/ run test",
     "lint": "tslint -c tslint.json -p .",
-    "tsc": "yarn run lint && tsc",
+    "tsc": "npm run lint && tsc",
     "bump-version": "vsts-bump --indent 4 task.json"
   },
   "author": "Pulumi",

--- a/buildAndReleaseTask/prComment.ts
+++ b/buildAndReleaseTask/prComment.ts
@@ -14,7 +14,8 @@ import {
     CommentThreadStatus,
     CommentType,
 } from "azure-devops-node-api/interfaces/GitInterfaces";
-import { TaskConfig } from "./taskConfig";
+
+import type { TaskConfig } from "models";
 
 export const PULUMI_LOG_FILENAME = "pulumi-out.log";
 

--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -14,7 +14,9 @@ import { TaskConfig } from "./taskConfig";
 
 import { createPrComment, PULUMI_LOG_FILENAME } from "./prComment";
 
-interface IEnvMap { [key: string]: string; }
+interface IEnvMap {
+    [key: string]: string;
+}
 
 interface IExecResult {
     exitCode: number;
@@ -36,12 +38,13 @@ async function runSelectStack(
     pulStack: string,
     toolPath: string,
     pulExecOptions: tr.IExecOptions,
-    additionalArgs?: string[],): Promise<IExecResult> {
+    additionalArgs?: string[]
+): Promise<IExecResult> {
     const stackSelectRunner = tl.tool(toolPath);
     let execErr = "";
     // The toolrunner emits an event when there is an error written to the stderr.
     // Listen for that event and update the execution error message accordingly.
-    stackSelectRunner.on("stderr", (errLine: string) => execErr = errLine);
+    stackSelectRunner.on("stderr", (errLine: string) => (execErr = errLine));
 
     let cmd = stackSelectRunner.arg(["stack", "select", pulStack!]);
     if (additionalArgs) {
@@ -56,7 +59,11 @@ async function runSelectStack(
  * fails, then creates the stack if the `createStack` task input is `true`,
  * IFF the stack selection failure was due to the stack not being found.
  */
-async function selectOrCreateStack(taskConfig: TaskConfig, toolPath: string, pulExecOptions: tr.IExecOptions): Promise<number> {
+async function selectOrCreateStack(
+    taskConfig: TaskConfig,
+    toolPath: string,
+    pulExecOptions: tr.IExecOptions
+): Promise<number> {
     const createStack = taskConfig.createStack;
     const pulStackFqdn = taskConfig.stack;
     if (!pulStackFqdn) {
@@ -67,9 +74,18 @@ async function selectOrCreateStack(taskConfig: TaskConfig, toolPath: string, pul
     if (createStack && cliVersionGreaterThan("1.10.0")) {
         // The `-c` flag was added in 1.10.0. Hopefully, no one is using that old of a CLI anymore.
         // But we still should make sure we don't try to use that flag on older versions.
-        selectStackExecResult = await runSelectStack(pulStackFqdn, toolPath, pulExecOptions, ["-c"]);
+        selectStackExecResult = await runSelectStack(
+            pulStackFqdn,
+            toolPath,
+            pulExecOptions,
+            ["-c"]
+        );
     } else {
-        selectStackExecResult = await runSelectStack(pulStackFqdn, toolPath, pulExecOptions);
+        selectStackExecResult = await runSelectStack(
+            pulStackFqdn,
+            toolPath,
+            pulExecOptions
+        );
     }
     if (selectStackExecResult.exitCode === 0) {
         return 0;
@@ -79,7 +95,10 @@ async function selectOrCreateStack(taskConfig: TaskConfig, toolPath: string, pul
     // check if the failure was due to the stack not being found, just
     // fail right away.
     if (!createStack) {
-        tl.setResult(tl.TaskResult.Failed, tl.loc("PulumiStackSelectFailed", pulStackFqdn));
+        tl.setResult(
+            tl.TaskResult.Failed,
+            tl.loc("PulumiStackSelectFailed", pulStackFqdn)
+        );
         return selectStackExecResult.exitCode;
     }
 
@@ -90,27 +109,42 @@ async function selectOrCreateStack(taskConfig: TaskConfig, toolPath: string, pul
     const parts = pulStackFqdn!.split("/");
     const errMsg = `no stack named '${parts[parts.length - 1]}' found`;
     if (!selectStackExecResult.execErr!.includes(errMsg)) {
-        tl.setResult(tl.TaskResult.Failed, tl.loc("PulumiStackSelectFailed", pulStackFqdn));
+        tl.setResult(
+            tl.TaskResult.Failed,
+            tl.loc("PulumiStackSelectFailed", pulStackFqdn)
+        );
         return selectStackExecResult.exitCode;
     }
 
     tl.debug(tl.loc("Debug_CreateStack", pulStackFqdn));
     const stackInitRunner = tl.tool(toolPath);
-    const exitCode = await stackInitRunner.arg(["stack", "init", pulStackFqdn!]).exec(pulExecOptions);
+    const exitCode = await stackInitRunner
+        .arg(["stack", "init", pulStackFqdn!])
+        .exec(pulExecOptions);
     if (exitCode !== 0) {
-        tl.setResult(tl.TaskResult.Failed, tl.loc("CreateStackFailed", pulStackFqdn));
+        tl.setResult(
+            tl.TaskResult.Failed,
+            tl.loc("CreateStackFailed", pulStackFqdn)
+        );
     }
     return exitCode;
 }
 
-function appendArgsToToolCmd(cmdRunner: tr.ToolRunner, args: string[]): tr.ToolRunner {
+function appendArgsToToolCmd(
+    cmdRunner: tr.ToolRunner,
+    args: string[]
+): tr.ToolRunner {
     args.forEach((arg: string) => {
         cmdRunner.arg(arg);
     });
     return cmdRunner;
 }
 
-async function runPulumiCmd(taskConfig: TaskConfig, toolPath: string, pulExecOptions: tr.IExecOptions) {
+async function runPulumiCmd(
+    taskConfig: TaskConfig,
+    toolPath: string,
+    pulExecOptions: tr.IExecOptions
+) {
     const pulCommand = taskConfig.command;
     if (!pulCommand) {
         throw new Error("Pulumi command is required");
@@ -128,7 +162,7 @@ async function runPulumiCmd(taskConfig: TaskConfig, toolPath: string, pulExecOpt
 
         logFile = createWriteStream(logFilePath);
         pulCommandRunner.on("stdout", (data: Buffer) => {
-           logFile?.write(data);
+            logFile?.write(data);
         });
     }
 
@@ -141,13 +175,22 @@ async function runPulumiCmd(taskConfig: TaskConfig, toolPath: string, pulExecOpt
     }
 
     if (exitCode !== 0) {
-        tl.setResult(tl.TaskResult.Failed,
-            tl.loc("PulumiCommandFailed", exitCode, `${pulCommand} ${pulArgs.join(" ")}`));
+        tl.setResult(
+            tl.TaskResult.Failed,
+            tl.loc(
+                "PulumiCommandFailed",
+                exitCode,
+                `${pulCommand} ${pulArgs.join(" ")}`
+            )
+        );
         return;
     }
 }
 
-function getExecOptions(envMap: IEnvMap, workingDirectory: string): tr.IExecOptions {
+function getExecOptions(
+    envMap: IEnvMap,
+    workingDirectory: string
+): tr.IExecOptions {
     return {
         cwd: workingDirectory,
         env: envMap,
@@ -176,7 +219,9 @@ function tryGetAzureEnvVarsFromServiceEndpoint(): IEnvMap {
 
     const serviceEndpoint = getServiceEndpoint(connectedServiceName);
     if (serviceEndpoint) {
-        tl.debug(`Service endpoint retrieved with client ID ${serviceEndpoint.clientId}`);
+        tl.debug(
+            `Service endpoint retrieved with client ID ${serviceEndpoint.clientId}`
+        );
     }
     if (!serviceEndpoint) {
         return {};
@@ -226,12 +271,17 @@ export async function runPulumi(taskConfig: TaskConfig) {
     // are not secret. Secret vars can only be retrieved using `tl.getVariable` or
     // `tl.getVariables`.
     const processEnv = process.env as IEnvMap;
-    tl.debug(`Executing Pulumi commands with process env ${JSON.stringify(processEnv)}`);
+    tl.debug(
+        `Executing Pulumi commands with process env ${JSON.stringify(
+            processEnv
+        )}`
+    );
 
     try {
         const toolPath = tl.which("pulumi");
         const agentEnvVars = tryGetEnvVars();
-        const azureServiceEndpointEnvVars = tryGetAzureEnvVarsFromServiceEndpoint();
+        const azureServiceEndpointEnvVars =
+            tryGetAzureEnvVarsFromServiceEndpoint();
         const loginEnvVars = {
             ...azureServiceEndpointEnvVars,
             ...agentEnvVars,
@@ -249,21 +299,30 @@ export async function runPulumi(taskConfig: TaskConfig) {
             // `getVariable` will automatically prepend the SECRET_ prefix if it finds
             // it in the build environment's secret vault.
             tl.getVariable(PULUMI_ACCESS_TOKEN);
-        if (!azureStorageContainer && !pulumiAccessToken && loginArgs.length === 0) {
-            tl.setResult(tl.TaskResult.Failed, tl.loc("PulumiLoginUndetermined"));
+        if (
+            !azureStorageContainer &&
+            !pulumiAccessToken &&
+            loginArgs.length === 0
+        ) {
+            tl.setResult(
+                tl.TaskResult.Failed,
+                tl.loc("PulumiLoginUndetermined")
+            );
             return;
         }
 
         let loginCommand = ["login"];
         if (azureStorageContainer) {
             loginCommand = ["login", "-c", `azblob://${azureStorageContainer}`];
-        }  else if (pulumiAccessToken) {
+        } else if (pulumiAccessToken) {
             loginEnvVars[PULUMI_ACCESS_TOKEN] = pulumiAccessToken;
         }
 
         let loginCmdRunner = tl.tool(toolPath).arg(loginCommand);
         loginCmdRunner = appendArgsToToolCmd(loginCmdRunner, loginArgs);
-        const exitCode = await loginCmdRunner.exec(getExecOptions(loginEnvVars, ""));
+        const exitCode = await loginCmdRunner.exec(
+            getExecOptions(loginEnvVars, "")
+        );
         if (exitCode !== 0) {
             tl.setResult(tl.TaskResult.Failed, tl.loc("PulumiLoginFailed"));
             return;
@@ -280,7 +339,11 @@ export async function runPulumi(taskConfig: TaskConfig) {
         const pulExecOptions = getExecOptions(envVars, pulCwd);
 
         // Select the stack.
-        const stackCmdExitCode = await selectOrCreateStack(taskConfig, toolPath, pulExecOptions);
+        const stackCmdExitCode = await selectOrCreateStack(
+            taskConfig,
+            toolPath,
+            pulExecOptions
+        );
         if (stackCmdExitCode !== 0) {
             return;
         }

--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -10,7 +10,8 @@ import { getServiceEndpoint } from "./serviceEndpoint";
 import { INSTALLED_PULUMI_VERSION, PULUMI_ACCESS_TOKEN } from "./vars";
 
 import { gt as semverGt } from "semver";
-import { TaskConfig } from "./taskConfig";
+
+import type { TaskConfig } from "models";
 
 import { createPrComment, PULUMI_LOG_FILENAME } from "./prComment";
 

--- a/buildAndReleaseTask/serviceEndpoint.ts
+++ b/buildAndReleaseTask/serviceEndpoint.ts
@@ -9,17 +9,38 @@ export interface IServiceEndpoint {
     clientId: string;
 }
 
-export function getServiceEndpoint(connectedServiceName: string): IServiceEndpoint | undefined {
-    const endpointAuthorization = tl.getEndpointAuthorization(connectedServiceName, true);
+export function getServiceEndpoint(
+    connectedServiceName: string
+): IServiceEndpoint | undefined {
+    const endpointAuthorization = tl.getEndpointAuthorization(
+        connectedServiceName,
+        true
+    );
     if (!endpointAuthorization) {
         return undefined;
     }
 
     const endpoint = {
-        clientId: tl.getEndpointAuthorizationParameter(connectedServiceName, "serviceprincipalid", false),
-        servicePrincipalKey: tl.getEndpointAuthorizationParameter(connectedServiceName, "serviceprincipalkey", false),
-        subscriptionId: tl.getEndpointDataParameter(connectedServiceName, "subscriptionid", false),
-        tenantId: tl.getEndpointAuthorizationParameter(connectedServiceName, "tenantid", false),
+        clientId: tl.getEndpointAuthorizationParameter(
+            connectedServiceName,
+            "serviceprincipalid",
+            false
+        ),
+        servicePrincipalKey: tl.getEndpointAuthorizationParameter(
+            connectedServiceName,
+            "serviceprincipalkey",
+            false
+        ),
+        subscriptionId: tl.getEndpointDataParameter(
+            connectedServiceName,
+            "subscriptionid",
+            false
+        ),
+        tenantId: tl.getEndpointAuthorizationParameter(
+            connectedServiceName,
+            "tenantid",
+            false
+        ),
     } as IServiceEndpoint;
 
     return endpoint;

--- a/buildAndReleaseTask/taskConfig.ts
+++ b/buildAndReleaseTask/taskConfig.ts
@@ -7,11 +7,11 @@ import * as tl from "azure-pipelines-task-lib/task";
 export interface TaskConfig {
     // Inputs that are not strictly required
     // task should be marked as optional here.
-    // But if a certain
-    // input is required because a dependent
-    // input was provided, you should still mark
-    // the input as optional here and assert the
-    // value at the place of its use.
+    // But if a certain input is required because
+    // a dependent input was provided, you should
+    // still mark the input as optional here
+    // and assert the value at the place of
+    // its use.
     azureSubscription?: string;
     command?: string;
     loginArgs?: string;

--- a/buildAndReleaseTask/taskConfig.ts
+++ b/buildAndReleaseTask/taskConfig.ts
@@ -6,7 +6,7 @@ import * as tl from "azure-pipelines-task-lib/task";
  */
 export interface TaskConfig {
     // Inputs that are not strictly required
-    // task should be marked as optional here. 
+    // task should be marked as optional here.
     // But if a certain
     // input is required because a dependent
     // input was provided, you should still mark
@@ -38,6 +38,6 @@ export function getTaskConfig(): TaskConfig {
         versionSpec: tl.getInput("versionSpec"),
         createStack: tl.getBoolInput("createStack"),
         createPrComment: tl.getBoolInput("createPrComment"),
-        useThreadedPrComments: tl.getBoolInput("useThreadedPrComments")
-    }
+        useThreadedPrComments: tl.getBoolInput("useThreadedPrComments"),
+    };
 }

--- a/buildAndReleaseTask/taskConfig.ts
+++ b/buildAndReleaseTask/taskConfig.ts
@@ -1,28 +1,6 @@
 import * as tl from "azure-pipelines-task-lib/task";
 
-/**
- * Represents this task's inputs as modeled in the task
- * manifest file `task.json`.
- */
-export interface TaskConfig {
-    // Inputs that are not strictly required
-    // task should be marked as optional here.
-    // But if a certain input is required because
-    // a dependent input was provided, you should
-    // still mark the input as optional here
-    // and assert the value at the place of
-    // its use.
-    azureSubscription?: string;
-    command?: string;
-    loginArgs?: string;
-    args?: string;
-    cwd?: string;
-    stack?: string;
-    versionSpec?: string;
-    createStack?: boolean;
-    createPrComment?: boolean;
-    useThreadedPrComments?: boolean;
-}
+import { TaskConfig } from "models";
 
 /**
  * Returns this task's inputs.

--- a/buildAndReleaseTask/tests/_suite.ts
+++ b/buildAndReleaseTask/tests/_suite.ts
@@ -11,7 +11,6 @@ function mustNotHaveErrorsOrWarnings(tr: ttm.MockTestRunner) {
 }
 
 describe("Pulumi task tests", () => {
-
     it("should install the CLI and run command", (done: Mocha.Done) => {
         const tp = path.join(__dirname, "success.js");
         const tr = new ttm.MockTestRunner(tp);
@@ -24,10 +23,26 @@ describe("Pulumi task tests", () => {
         // for some odd reason, doing so is causing the mock-test library to print debugging
         // output always, even when not setting the `TASK_TEST_TRACE` env var before running the test.
         const expectedVersion = "0.16.5";
-        assert.strictEqual(stdout.indexOf(expectedVersion) >= 0, true, "should execute `pulumi version` command");
-        assert.strictEqual(stdout.indexOf("stack selected") >= 0, true, "should select stack");
-        assert.strictEqual(stdout.indexOf("fake logged in") >= 0, true, "should login");
-        assert.strictEqual(stdout.indexOf("fake pulumi preview") >= 0, true, "should execute `pulumi preview` command");
+        assert.strictEqual(
+            stdout.indexOf(expectedVersion) >= 0,
+            true,
+            "should execute `pulumi version` command"
+        );
+        assert.strictEqual(
+            stdout.indexOf("stack selected") >= 0,
+            true,
+            "should select stack"
+        );
+        assert.strictEqual(
+            stdout.indexOf("fake logged in") >= 0,
+            true,
+            "should login"
+        );
+        assert.strictEqual(
+            stdout.indexOf("fake pulumi preview") >= 0,
+            true,
+            "should execute `pulumi preview` command"
+        );
 
         done();
     });
@@ -51,7 +66,8 @@ describe("Pulumi task tests", () => {
         assert.strictEqual(
             tr.stdout.indexOf("fake logged in using azure storage") >= 0,
             true,
-            "should login using azure environment variables");
+            "should login using azure environment variables"
+        );
 
         done();
     });
@@ -62,7 +78,11 @@ describe("Pulumi task tests", () => {
 
         tr.run();
         mustNotHaveErrorsOrWarnings(tr);
-        assert.strictEqual(tr.stdout.indexOf("Created stack") >= 0, true, "should create stack");
+        assert.strictEqual(
+            tr.stdout.indexOf("Created stack") >= 0,
+            true,
+            "should create stack"
+        );
 
         done();
     });

--- a/buildAndReleaseTask/tests/create_stack_if_not_found.ts
+++ b/buildAndReleaseTask/tests/create_stack_if_not_found.ts
@@ -17,8 +17,7 @@ const stackNameFqdn = "myorg/myproject/nonExistentStack";
 // If the user requested version is not `latest`, then this is the version
 // that the task should install.
 export const userRequestedVersion = "1.9.0";
-const expectedDownloadUrl =
-    `https://get.pulumi.com/releases/sdk/pulumi-v${userRequestedVersion}-${fakeOS.toLowerCase()}-x64.tar.gz`;
+const expectedDownloadUrl = `https://get.pulumi.com/releases/sdk/pulumi-v${userRequestedVersion}-${fakeOS.toLowerCase()}-x64.tar.gz`;
 const fakeDownloadedPath = "/fake/path/to/downloaded/file";
 
 process.env["HOME"] = "/fake/home";
@@ -61,24 +60,28 @@ tmr.registerMock("azure-pipelines-tool-lib", {
     },
     extractTar: (downloadedPath: string) => {
         if (downloadedPath !== fakeDownloadedPath) {
-            throw new Error(`Unexpected downloaded file path ${downloadedPath}`);
+            throw new Error(
+                `Unexpected downloaded file path ${downloadedPath}`
+            );
         }
         return Promise.resolve("/fake/path/to/extracted/contents");
     },
     extractZip: (downloadedPath: string) => {
         if (downloadedPath !== fakeDownloadedPath) {
-            throw new Error(`Unexpected downloaded file path ${downloadedPath}`);
+            throw new Error(
+                `Unexpected downloaded file path ${downloadedPath}`
+            );
         }
         return Promise.resolve("/fake/path/to/extracted/contents");
     },
     prependPath: (pathToTool: string) => {
-        console.log(`prepending path ${ pathToTool }`);
+        console.log(`prepending path ${pathToTool}`);
     },
 });
 
 tmr.registerMock("azure-pipelines-tool-lib/tool", {
     findLocalTool: (toolName: string, version: string) => {
-        console.log(`Requested tool ${ toolName } of version ${ version }`);
+        console.log(`Requested tool ${toolName} of version ${version}`);
         return undefined;
     },
 });
@@ -110,7 +113,7 @@ const mockAnswers: ma.TaskLibAnswers = {
     },
     which: {
         "/fake/path/to/pulumi": "/fake/path/to/pulumi",
-        "pulumi": "/fake/path/to/pulumi",
+        pulumi: "/fake/path/to/pulumi",
     },
 } as ma.TaskLibAnswers;
 

--- a/buildAndReleaseTask/tests/envvars.ts
+++ b/buildAndReleaseTask/tests/envvars.ts
@@ -14,8 +14,7 @@ const latestPulumiVersion = "1.5.1";
 // If the user requested version is not `latest`, then this is the version
 // that the task should install.
 export const userRequestedVersion = "0.16.5";
-const expectedDownloadUrl =
-    `https://get.pulumi.com/releases/sdk/pulumi-v${userRequestedVersion}-${fakeOS.toLowerCase()}-x64.tar.gz`;
+const expectedDownloadUrl = `https://get.pulumi.com/releases/sdk/pulumi-v${userRequestedVersion}-${fakeOS.toLowerCase()}-x64.tar.gz`;
 const fakeDownloadedPath = "/fake/path/to/downloaded/file";
 
 process.env["HOME"] = "/fake/home";
@@ -56,24 +55,28 @@ tmr.registerMock("azure-pipelines-tool-lib", {
     },
     extractTar: (downloadedPath: string) => {
         if (downloadedPath !== fakeDownloadedPath) {
-            throw new Error(`Unexpected downloaded file path ${downloadedPath}`);
+            throw new Error(
+                `Unexpected downloaded file path ${downloadedPath}`
+            );
         }
         return Promise.resolve("/fake/path/to/extracted/contents");
     },
     extractZip: (downloadedPath: string) => {
         if (downloadedPath !== fakeDownloadedPath) {
-            throw new Error(`Unexpected downloaded file path ${downloadedPath}`);
+            throw new Error(
+                `Unexpected downloaded file path ${downloadedPath}`
+            );
         }
         return Promise.resolve("/fake/path/to/extracted/contents");
     },
     prependPath: (pathToTool: string) => {
-        console.log(`prepending path ${ pathToTool }`);
+        console.log(`prepending path ${pathToTool}`);
     },
 });
 
 tmr.registerMock("azure-pipelines-tool-lib/tool", {
     findLocalTool: (toolName: string, version: string) => {
-        console.log(`Requested tool ${ toolName } of version ${ version }`);
+        console.log(`Requested tool ${toolName} of version ${version}`);
         return undefined;
     },
 });
@@ -109,7 +112,7 @@ const mockAnswers: ma.TaskLibAnswers = {
     },
     which: {
         "/fake/path/to/pulumi": "/fake/path/to/pulumi",
-        "pulumi": "/fake/path/to/pulumi",
+        pulumi: "/fake/path/to/pulumi",
     },
 } as ma.TaskLibAnswers;
 

--- a/buildAndReleaseTask/tests/envvars_storage.ts
+++ b/buildAndReleaseTask/tests/envvars_storage.ts
@@ -14,8 +14,7 @@ const latestPulumiVersion = "1.5.1";
 // If the user requested version is not `latest`, then this is the version
 // that the task should install.
 export const userRequestedVersion = "0.16.5";
-const expectedDownloadUrl =
-    `https://get.pulumi.com/releases/sdk/pulumi-v${userRequestedVersion}-${fakeOS.toLowerCase()}-x64.tar.gz`;
+const expectedDownloadUrl = `https://get.pulumi.com/releases/sdk/pulumi-v${userRequestedVersion}-${fakeOS.toLowerCase()}-x64.tar.gz`;
 const fakeDownloadedPath = "/fake/path/to/downloaded/file";
 
 process.env["HOME"] = "/fake/home";
@@ -57,24 +56,28 @@ tmr.registerMock("azure-pipelines-tool-lib", {
     },
     extractTar: (downloadedPath: string) => {
         if (downloadedPath !== fakeDownloadedPath) {
-            throw new Error(`Unexpected downloaded file path ${downloadedPath}`);
+            throw new Error(
+                `Unexpected downloaded file path ${downloadedPath}`
+            );
         }
         return Promise.resolve("/fake/path/to/extracted/contents");
     },
     extractZip: (downloadedPath: string) => {
         if (downloadedPath !== fakeDownloadedPath) {
-            throw new Error(`Unexpected downloaded file path ${downloadedPath}`);
+            throw new Error(
+                `Unexpected downloaded file path ${downloadedPath}`
+            );
         }
         return Promise.resolve("/fake/path/to/extracted/contents");
     },
     prependPath: (pathToTool: string) => {
-        console.log(`prepending path ${ pathToTool }`);
+        console.log(`prepending path ${pathToTool}`);
     },
 });
 
 tmr.registerMock("azure-pipelines-tool-lib/tool", {
     findLocalTool: (toolName: string, version: string) => {
-        console.log(`Requested tool ${ toolName } of version ${ version }`);
+        console.log(`Requested tool ${toolName} of version ${version}`);
         return undefined;
     },
 });
@@ -110,7 +113,7 @@ const mockAnswers: ma.TaskLibAnswers = {
     },
     which: {
         "/fake/path/to/pulumi": "/fake/path/to/pulumi",
-        "pulumi": "/fake/path/to/pulumi",
+        pulumi: "/fake/path/to/pulumi",
     },
 } as ma.TaskLibAnswers;
 

--- a/buildAndReleaseTask/tests/success.ts
+++ b/buildAndReleaseTask/tests/success.ts
@@ -16,8 +16,7 @@ const latestPulumiVersion = "1.5.1";
 // If the user requested version is not `latest`, then this is the version
 // that the task should install.
 const userRequestedVersion = "0.16.5";
-const expectedDownloadUrl =
-    `https://get.pulumi.com/releases/sdk/pulumi-v${userRequestedVersion}-${fakeOS.toLowerCase()}-x64.tar.gz`;
+const expectedDownloadUrl = `https://get.pulumi.com/releases/sdk/pulumi-v${userRequestedVersion}-${fakeOS.toLowerCase()}-x64.tar.gz`;
 const fakeDownloadedPath = "/fake/path/to/downloaded/file";
 
 process.env["HOME"] = "/fake/home";
@@ -59,24 +58,28 @@ tmr.registerMock("azure-pipelines-tool-lib", {
     },
     extractTar: (downloadedPath: string) => {
         if (downloadedPath !== fakeDownloadedPath) {
-            throw new Error(`Unexpected downloaded file path ${downloadedPath}`);
+            throw new Error(
+                `Unexpected downloaded file path ${downloadedPath}`
+            );
         }
         return Promise.resolve("/fake/path/to/extracted/contents");
     },
     extractZip: (downloadedPath: string) => {
         if (downloadedPath !== fakeDownloadedPath) {
-            throw new Error(`Unexpected downloaded file path ${downloadedPath}`);
+            throw new Error(
+                `Unexpected downloaded file path ${downloadedPath}`
+            );
         }
         return Promise.resolve("/fake/path/to/extracted/contents");
     },
     prependPath: (pathToTool: string) => {
-        console.log(`prepending path ${ pathToTool }`);
+        console.log(`prepending path ${pathToTool}`);
     },
 });
 
 tmr.registerMock("azure-pipelines-tool-lib/tool", {
     findLocalTool: (toolName: string, version: string) => {
-        console.log(`Requested tool ${ toolName } of version ${ version }`);
+        console.log(`Requested tool ${toolName} of version ${version}`);
         return undefined;
     },
 });
@@ -112,7 +115,7 @@ const mockAnswers: ma.TaskLibAnswers = {
     },
     which: {
         "/fake/path/to/pulumi": "/fake/path/to/pulumi",
-        "pulumi": "/fake/path/to/pulumi",
+        pulumi: "/fake/path/to/pulumi",
     },
 } as ma.TaskLibAnswers;
 

--- a/buildAndReleaseTask/version.ts
+++ b/buildAndReleaseTask/version.ts
@@ -4,12 +4,15 @@ import * as axios from "axios";
 import * as tl from "azure-pipelines-task-lib/task";
 
 export async function getLatestPulumiVersion(): Promise<string> {
-    const resp = await axios.default.get<string>("https://www.pulumi.com/latest-version", {
-        headers: {
-            "Content-Type": "text/plain",
-            "User-Agent": "pulumi-azure-pipelines-task",
-        },
-    });
+    const resp = await axios.default.get<string>(
+        "https://www.pulumi.com/latest-version",
+        {
+            headers: {
+                "Content-Type": "text/plain",
+                "User-Agent": "pulumi-azure-pipelines-task",
+            },
+        }
+    );
     // The response contains a new-line character at the end, so let's replace it.
     const version = resp.data.replace("\n", "");
     tl.debug(tl.loc("Debug_LatestPulumiVersion", version));

--- a/package.azure-pipelines.yml
+++ b/package.azure-pipelines.yml
@@ -4,48 +4,48 @@
 trigger: none
 
 jobs:
-- job: tfxCreate
-  pool:
-    vmImage: 'ubuntu-latest'
-  displayName: 'Create and package VSIX'
-  steps:
-  - task: Npm@1
-    displayName: 'Restore node_modules for buildAndReleaseTask/'
-    inputs:
-      workingDir: buildAndReleaseTask/
-      verbose: true
+  - job: tfxCreate
+    pool:
+      vmImage: "ubuntu-latest"
+    displayName: "Create and package VSIX"
+    steps:
+      - task: Npm@1
+        displayName: "Restore node_modules for buildAndReleaseTask/"
+        inputs:
+          workingDir: buildAndReleaseTask/
+          verbose: true
 
-  - task: Npm@1
-    displayName: 'Compile TS to JS'
-    inputs:
-      workingDir: buildAndReleaseTask/
-      command: 'custom'
-      customCommand: run tsc
+      - task: Npm@1
+        displayName: "Compile TS to JS"
+        inputs:
+          workingDir: buildAndReleaseTask/
+          command: "custom"
+          customCommand: run tsc
 
-  - task: TfxInstaller@2
-    inputs:
-      version: 'v0.8.x'
+      - task: TfxInstaller@2
+        inputs:
+          version: "v0.8.x"
 
-  - task: QueryAzureDevOpsExtensionVersion@3
-    displayName: 'Query extension version'
-    inputs:
-      connectTo: 'VsTeam'
-      connectedServiceName: 'Pulumi Marketplace'
-      publisherId: 'pulumi'
-      extensionId: 'build-and-release-task'
-      versionAction: 'Patch'
-      outputVariable: 'PulumiExtension.Version'
-      extensionVersionOverride: 'PulumiExtension.VersionOverride'
+      - task: QueryAzureDevOpsExtensionVersion@3
+        displayName: "Query extension version"
+        inputs:
+          connectTo: "VsTeam"
+          connectedServiceName: "Pulumi Marketplace"
+          publisherId: "pulumi"
+          extensionId: "build-and-release-task"
+          versionAction: "Patch"
+          outputVariable: "PulumiExtension.Version"
+          extensionVersionOverride: "PulumiExtension.VersionOverride"
 
-  - task: PackageAzureDevOpsExtension@3
-    displayName: 'Package extension'
-    inputs:
-      extensionVersion: '$(PulumiExtension.Version)'
-      updateTasksVersion: true
-      outputVariable: 'PulumiExtension.OutputPath'
+      - task: PackageAzureDevOpsExtension@3
+        displayName: "Package extension"
+        inputs:
+          extensionVersion: "$(PulumiExtension.Version)"
+          updateTasksVersion: true
+          outputVariable: "PulumiExtension.OutputPath"
 
-  - task: PublishPipelineArtifact@0
-    displayName: 'Create pipeline artifact'
-    inputs:
-      artifactName: 'vsix'
-      targetPath: $(PulumiExtension.OutputPath)
+      - task: PublishPipelineArtifact@0
+        displayName: "Create pipeline artifact"
+        inputs:
+          artifactName: "vsix"
+          targetPath: $(PulumiExtension.OutputPath)

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Azure Pipelines task extension for running Pulumi apps.",
   "main": "index.js",
   "scripts": {
-    "package": "yarn --cwd buildAndReleaseTask/ run tsc && yarn --cwd buildAndReleaseTask/ bump-version && yarn run tfx-create",
-    "start": "yarn --cwd buildAndReleaseTask/ run tsc && node buildAndReleaseTask/index.js",
-    "test": "yarn --cwd buildAndReleaseTask/ test",
+    "package": "npm --prefix buildAndReleaseTask/ run tsc && npm --prefix buildAndReleaseTask/ bump-version && npm run tfx-create",
+    "start": "npm --prefix buildAndReleaseTask/ run tsc && node buildAndReleaseTask/index.js",
+    "lint": "npm --prefix buildAndReleaseTask/ run lint",
+    "test": "npm --prefix buildAndReleaseTask/ test",
     "tfx-create": "tfx extension create --manifest-globs vss-extension.json --rev-version"
   },
   "author": "Pulumi",


### PR DESCRIPTION
@RobbieMcKinstry as discussed, this PR with various miscellaneous fixes. The highlight of the PR is to run lint as part of CI/PR builds. Most of the changes come from the first commit in this PR, which is related to re-enabling code formatting with Prettier.

I also decided to pull out the `TaskConfig` interface into a type definition file after all, given how much trouble it led to in my previous PR with the incorrect import. It should help avoid similar problems for others in the future.

-------

* [x] If you changed the values of the properties `name`, `publisher`, and `galleryFlags` in the `vss-extension.json` file, you have reverted them.
* [x] If you changed the values of the properties `id`, `name`, `author`, you have reverted them.
* [x] I have reverted any changes to the version number components in both `vss-extension.json` and `task.json`, OR I didn't change them.
