### PR TITLE
PR comment feature should be opt-in and not enabled by default

### DIFF
--- a/buildAndReleaseTask/prComment.ts
+++ b/buildAndReleaseTask/prComment.ts
@@ -89,6 +89,12 @@ export async function createPrComment(taskConfig: TaskConfig) {
         return;
     }
 
+    const hostType = tl.getVariable("System.HostType");
+    if (hostType?.toLowerCase() !== "build") {
+        tl.warning(tl.loc("Warning_NotABuildPipeline", hostType));
+        return;
+    }
+
     const repoProvider = tl.getVariable("Build.Repository.Provider");
     if (repoProvider !== "TfsGit") {
         tl.warning(tl.loc("Warning_UnSupportedRepositoryType", repoProvider));

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -105,7 +105,7 @@
             "name": "createPrComment",
             "type": "boolean",
             "label": "Add the Pulumi log output as a PR comment",
-            "defaultValue": "true",
+            "defaultValue": "false",
             "helpMarkDown": "Check this option if you would like this task to add a comment to your PR (when applicable.) **Note**: Your project's build service user must have the `Contribute to pull requests` permission for this to work. Additionally, you must map the `System.AccessToken` variable as an env var for this task: `SYSTEM_ACCESSTOKEN: $(System.AccessToken)`.",
             "required": "false"
         },
@@ -113,7 +113,7 @@
             "name": "useThreadedPrComments",
             "type": "boolean",
             "label": "Add PR comments to an existing thread (if any) created by this task",
-            "defaultValue": "false",
+            "defaultValue": "true",
             "groupName": "advanced",
             "helpMarkDown": "Check this option if you would like this task to always add a comment to the previously-created comments thread.",
             "required": "false",

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -157,6 +157,7 @@
         "Debug_ExistingThreadNotFound": "An existing comment thread created by this task was not found. A new thread will be started.",
         "Debug_ThreadFound": "Found an existing comment thread created by this task. A new comment will be added to it.",
         "Warning_ExistingCommentThreadNotFound": "Did not find an existing comment thread for Pulumi output. Will start a new one.",
-        "Warning_UnSupportedRepositoryType": "Repository type %s is not yet supported for PR comments."
+        "Warning_UnSupportedRepositoryType": "Repository type %s is not yet supported for PR comments.",
+        "Warning_NotABuildPipeline": "Ignoring request to create a PR comment. PR comments are only applicable for build pipelines. The pipeline is a %s."
     }
 }

--- a/buildAndReleaseTask/tests/_suite.ts
+++ b/buildAndReleaseTask/tests/_suite.ts
@@ -45,7 +45,9 @@ describe("Pulumi task tests", () => {
         );
 
         done();
-    });
+    }).timeout(3000);
+    // Set a higher timeout for the above test since it seems to take
+    // some additional time to run sometimes.
 
     it("should run Pulumi with the expected env vars", (done: Mocha.Done) => {
         const tp = path.join(__dirname, "envvars.js");

--- a/overview.md
+++ b/overview.md
@@ -223,4 +223,4 @@ variables:
 ### `Error: TF401027: You need the Git 'PullRequestContribute' permission to perform this action.`
 
 This error indicates that the service account used by build pipelines in your DevOps project do not have the `Contribute Pull Request` permission.
-Follow the steps outlined in the **Quickstart** section above.
+Follow the steps outlined in the **Quickstart** section above..

--- a/overview.md
+++ b/overview.md
@@ -13,11 +13,10 @@ Read on to learn how you can get started quickly.
 
 ## Prerequisites
 
-- You must have an active Azure subscription. Create a new subscription at https://azure.com.
-- You must also have an active Azure DevOps account and an organization. Create a new account at https://dev.azure.com.
+- You must have an active Azure DevOps account and an organization. Create a new account at https://dev.azure.com.
 - Install this extension to your organization. To do this, you must be an admin of the organization.
   - Once installed, you may have to have your admin make the extension available to you or your project.
-- Create a [service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/connect-to-azure?view=azure-devops) to your Azure Subscription in your DevOps project.
+- You'll need an Azure subscription if you plan on creating resources in Azure. Create a [service connection](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/connect-to-azure?view=azure-devops) for the Azure Subscription in your DevOps project.
   - **Note**: At this time, only a `Service Principal Authentication` based service connection can be used with this extension.
   - The name of this service connection is what you will use in the Pulumi task for the input `azureSubscription` if you are using the YAML configuration.
 

--- a/overview.md
+++ b/overview.md
@@ -223,4 +223,4 @@ variables:
 ### `Error: TF401027: You need the Git 'PullRequestContribute' permission to perform this action.`
 
 This error indicates that the service account used by build pipelines in your DevOps project do not have the `Contribute Pull Request` permission.
-Follow the steps outlined in the **Quickstart** section above..
+Follow the steps outlined in the **Quickstart** section above.


### PR DESCRIPTION
This PR should fix #118. The default value for the PR comment input should be `false` and the default value for using threaded comments should be `true`. These were flipped unfortunately when the feature was added, which caused release pipelines to fail since the task was throwing an error about the lack of a PR ID.

--------

* [x] If you changed the values of the properties `name`, `publisher`, and `galleryFlags` in the `vss-extension.json` file, you have reverted them.
* [x] If you changed the values of the properties `id`, `name`, `author`, you have reverted them.
* [x] I have reverted any changes to the version number components in both `vss-extension.json` and `task.json`, OR I didn't change them.
