### PR TITLE
Make subscriptionId an optional parameter when looking up the endpoint service metadata

### DIFF
--- a/buildAndReleaseTask/pulumi.ts
+++ b/buildAndReleaseTask/pulumi.ts
@@ -281,8 +281,7 @@ export async function runPulumi(taskConfig: TaskConfig) {
     try {
         const toolPath = tl.which("pulumi");
         const agentEnvVars = tryGetEnvVars();
-        const azureServiceEndpointEnvVars =
-            tryGetAzureEnvVarsFromServiceEndpoint();
+        const azureServiceEndpointEnvVars = tryGetAzureEnvVarsFromServiceEndpoint();
         const loginEnvVars = {
             ...azureServiceEndpointEnvVars,
             ...agentEnvVars,

--- a/buildAndReleaseTask/serviceEndpoint.ts
+++ b/buildAndReleaseTask/serviceEndpoint.ts
@@ -31,12 +31,12 @@ export function getServiceEndpoint(
             "serviceprincipalkey",
             false
         ),
-        // It is entirely possible subscriptionId is not present, so setting subscription as optional stops an unintended failure. 
+        // It is entirely possible subscriptionId is not present, so setting subscription as optional stops an unintended failure.
         // eg- a ManagementGroup scoped SP has access to multiple subscriptions; the subscription that is the target of a pulumi up will be enforced in the pulumi program config/env.
         subscriptionId: tl.getEndpointDataParameter(
             connectedServiceName,
             "subscriptionid",
-            true 
+            true
         ),
         tenantId: tl.getEndpointAuthorizationParameter(
             connectedServiceName,

--- a/buildAndReleaseTask/serviceEndpoint.ts
+++ b/buildAndReleaseTask/serviceEndpoint.ts
@@ -31,10 +31,12 @@ export function getServiceEndpoint(
             "serviceprincipalkey",
             false
         ),
+        // It is entirely possible subscriptionId is not present, so setting subscription as optional stops an unintended failure. 
+        // eg- a ManagementGroup scoped SP has access to multiple subscriptions; the subscription that is the target of a pulumi up will be enforced in the pulumi program config/env.
         subscriptionId: tl.getEndpointDataParameter(
             connectedServiceName,
             "subscriptionid",
-            false
+            true 
         ),
         tenantId: tl.getEndpointAuthorizationParameter(
             connectedServiceName,
@@ -45,3 +47,4 @@ export function getServiceEndpoint(
 
     return endpoint;
 }
+// 500-1000 per tenant


### PR DESCRIPTION


Thank you for contributing! Before submitting your PR, can you please confirm that you have done the following?

* [ ] If you changed the values of the properties `name`, `publisher`, and `galleryFlags` in the `vss-extension.json` file, you have reverted them.
* [ ] If you changed the values of the properties `id`, `name`, `author`, you have reverted them.
* [ ] I have reverted any changes to the version number components in both `vss-extension.json` and `task.json`, OR I didn't change them.
* 
fixes: [#122](https://github.com/pulumi/pulumi-az-pipelines-task/issues/122)
