### PR TITLE
Support workload identity federation service connection (#147)

### DIFF
--- a/buildAndReleaseTask/package-lock.json
+++ b/buildAndReleaseTask/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.6.2",
         "azure-devops-node-api": "^12.1.0",
         "azure-pipelines-task-lib": "^4.7.0",
+        "azure-pipelines-tasks-artifacts-common": "^2.230.0",
         "azure-pipelines-tool-lib": "^2.0.7",
         "semver": "^7.5.4",
         "typed-rest-client": "^1.8.11"
@@ -71,6 +72,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.0.tgz",
+      "integrity": "sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mocha": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
@@ -80,8 +89,7 @@
     "node_modules/@types/node": {
       "version": "16.18.68",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
-      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg==",
-      "dev": true
+      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
     },
     "node_modules/@types/q": {
       "version": "1.5.4",
@@ -231,6 +239,42 @@
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-artifacts-common": {
+      "version": "2.230.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-artifacts-common/-/azure-pipelines-tasks-artifacts-common-2.230.0.tgz",
+      "integrity": "sha512-FWyRjR+eqNjjVvXwiIJVcfLN+DTmbS3icRgrL6zAGx7iIKJOJn+sjlKOuCIR36TaWU4KOVfDGJujDK6Z+WPY8g==",
+      "dependencies": {
+        "@types/fs-extra": "8.0.0",
+        "@types/mocha": "^5.2.6",
+        "@types/node": "^16.11.39",
+        "azure-devops-node-api": "12.0.0",
+        "azure-pipelines-task-lib": "^4.2.0",
+        "fs-extra": "8.1.0",
+        "semver": "6.3.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+    },
+    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/azure-devops-node-api": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.0.0.tgz",
+      "integrity": "sha512-S6Il++7dQeMlZDokBDWw7YVoPeb90tWF10pYxnoauRMnkuL91jq9M7SOYRVhtO3FUC5URPkB/qzGa7jTLft0Xw==",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/azure-pipelines-tool-lib": {
@@ -517,6 +561,19 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -567,6 +624,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -697,6 +759,14 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/lru-cache": {
@@ -1161,6 +1231,14 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
       "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
@@ -1268,6 +1346,14 @@
         "@types/node": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.0.tgz",
+      "integrity": "sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mocha": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
@@ -1277,8 +1363,7 @@
     "@types/node": {
       "version": "16.18.68",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
-      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg==",
-      "dev": true
+      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1410,6 +1495,41 @@
           "version": "5.7.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
           "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+        }
+      }
+    },
+    "azure-pipelines-tasks-artifacts-common": {
+      "version": "2.230.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-artifacts-common/-/azure-pipelines-tasks-artifacts-common-2.230.0.tgz",
+      "integrity": "sha512-FWyRjR+eqNjjVvXwiIJVcfLN+DTmbS3icRgrL6zAGx7iIKJOJn+sjlKOuCIR36TaWU4KOVfDGJujDK6Z+WPY8g==",
+      "requires": {
+        "@types/fs-extra": "8.0.0",
+        "@types/mocha": "^5.2.6",
+        "@types/node": "^16.11.39",
+        "azure-devops-node-api": "12.0.0",
+        "azure-pipelines-task-lib": "^4.2.0",
+        "fs-extra": "8.1.0",
+        "semver": "6.3.0"
+      },
+      "dependencies": {
+        "@types/mocha": {
+          "version": "5.2.7",
+          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+          "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+        },
+        "azure-devops-node-api": {
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.0.0.tgz",
+          "integrity": "sha512-S6Il++7dQeMlZDokBDWw7YVoPeb90tWF10pYxnoauRMnkuL91jq9M7SOYRVhtO3FUC5URPkB/qzGa7jTLft0Xw==",
+          "requires": {
+            "tunnel": "0.0.6",
+            "typed-rest-client": "^1.8.4"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -1630,6 +1750,16 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1668,6 +1798,11 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "has": {
       "version": "1.0.3",
@@ -1773,6 +1908,14 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "lru-cache": {
@@ -2147,6 +2290,11 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
       "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "utf8-byte-length": {
       "version": "1.0.4",

--- a/buildAndReleaseTask/package.json
+++ b/buildAndReleaseTask/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.6.2",
     "azure-devops-node-api": "^12.1.0",
     "azure-pipelines-task-lib": "^4.7.0",
+    "azure-pipelines-tasks-artifacts-common": "^2.230.0",
     "azure-pipelines-tool-lib": "^2.0.7",
     "semver": "^7.5.4",
     "typed-rest-client": "^1.8.11"

--- a/buildAndReleaseTask/serviceEndpoint.ts
+++ b/buildAndReleaseTask/serviceEndpoint.ts
@@ -1,23 +1,32 @@
 // Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
 
+import { getHandlerFromToken, WebApi } from "azure-devops-node-api";
+import { ITaskApi } from "azure-devops-node-api/TaskApi";
 import * as tl from "azure-pipelines-task-lib/task";
+import { getSystemAccessToken } from "azure-pipelines-tasks-artifacts-common/webapi";
 
 export interface IServiceEndpoint {
     subscriptionId: string;
-    servicePrincipalKey: string;
+    oidcToken?: string;
+    servicePrincipalKey?: string;
     tenantId: string;
     clientId: string;
 }
 
-export function getServiceEndpoint(
+export async function getServiceEndpoint(
     connectedServiceName: string
-): IServiceEndpoint | undefined {
+): Promise<IServiceEndpoint | undefined> {
     const endpointAuthorization = tl.getEndpointAuthorization(
         connectedServiceName,
         true
     );
     if (!endpointAuthorization) {
         return undefined;
+    }
+
+    const oidcEndpoint = await tryGetOidcServiceEndpoint(connectedServiceName);
+    if (oidcEndpoint) {
+        return oidcEndpoint;
     }
 
     const endpoint = {
@@ -46,5 +55,86 @@ export function getServiceEndpoint(
     } as IServiceEndpoint;
 
     return endpoint;
+}
+
+/**
+ * Tries to get the endpoint details for a workload identity federation
+ * service connection as per V2 of the Azure CLI task
+ * https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureCLIV2/azureclitask.ts#L143-L152
+ */
+async function tryGetOidcServiceEndpoint(
+    connectedServiceName: string
+): Promise<IServiceEndpoint | undefined> {
+    const authScheme = tl.getEndpointAuthorizationScheme(
+        connectedServiceName,
+        true
+    );
+    tl.debug(`Service endpoint authorization scheme ${authScheme ?? ""}`);
+    if (authScheme?.toLowerCase() !== "workloadidentityfederation") {
+        return undefined;
+    }
+
+    const federatedToken = await tryGetIdToken(connectedServiceName);
+
+    if (!federatedToken) {
+        return undefined;
+    }
+
+    tl.setSecret(federatedToken);
+
+    const endpoint = {
+        clientId: tl.getEndpointAuthorizationParameter(
+            connectedServiceName,
+            "serviceprincipalid",
+            false
+        ),
+        oidcToken: federatedToken,
+        // It is entirely possible subscriptionId is not present, so setting subscription as optional stops an unintended failure.
+        // eg- a ManagementGroup scoped SP has access to multiple subscriptions; the subscription that is the target of a pulumi up will be enforced in the pulumi program config/env.
+        subscriptionId: tl.getEndpointDataParameter(
+            connectedServiceName,
+            "subscriptionid",
+            true
+        ),
+        tenantId: tl.getEndpointAuthorizationParameter(
+            connectedServiceName,
+            "tenantid",
+            false
+        ),
+    } as IServiceEndpoint;
+
+    return endpoint;
+}
+
+/**
+ * Tries to get the ID token as per V2 of the Azure CLI task
+ * https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureCLIV2/azureclitask.ts#L251-L268
+ */
+async function tryGetIdToken(
+    connectedService: string
+): Promise<string | undefined | null> {
+    const jobId = tl.getVariable("System.JobId")!;
+    const planId = tl.getVariable("System.PlanId")!;
+    const projectId = tl.getVariable("System.TeamProjectId")!;
+    const hub = tl.getVariable("System.HostType")!;
+    const uri = tl.getVariable("System.CollectionUri")!;
+    const token = getSystemAccessToken();
+
+    const authHandler = getHandlerFromToken(token);
+    const connection = new WebApi(uri, authHandler);
+    const api: ITaskApi = await connection.getTaskApi();
+    const response = await api.createOidcToken(
+        {},
+        projectId,
+        hub,
+        planId,
+        jobId,
+        connectedService
+    );
+    if (response == null) {
+        return null;
+    }
+
+    return response.oidcToken;
 }
 // 500-1000 per tenant


### PR DESCRIPTION
Add support for [Workload identity federation for Azure service connections](https://devblogs.microsoft.com/devops/workload-identity-federation-for-azure-deployments-is-now-generally-available/).

This change is based on the implementation in the [Azure CLI Task V2](https://github.com/microsoft/azure-pipelines-tasks/blob/5278dc64cd07ce067e40f3e4a2bf5e15edf12b57/Tasks/AzureCLIV2/azureclitask.ts).

Added [azure-pipelines-tasks-artifacts-common@2.230.0](https://www.npmjs.com/package/azure-pipelines-tasks-artifacts-common/v/2.230.0) so the [getSystemAccessToken](https://github.com/microsoft/azure-pipelines-tasks/blob/68caa90dd430a9f2a1cb2cacc1d8b6fcc48fbb71/Tasks/GradleV3/Modules/environment.ts#L10-L27) function could be used to get the system token to auth the request for the creation of the OIDC token.

Tested in my Azure DevOps organisation with a new Pulumi project created using the Azure C# template which successfully deployed in pipeline run [20240505.12](https://dev.azure.com/brdbr/public-playground/_build/results?buildId=438&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=eb980582-45a7-5e52-4a39-69f73379d8d6).

Related to #147 

Thank you for contributing! Before submitting your PR, can you please confirm that you have done the following?

* [x] If you changed the values of the properties `name`, `publisher`, and `galleryFlags` in the `vss-extension.json` file, you have reverted them.
* [x] If you changed the values of the properties `id`, `name`, `author`, you have reverted them.
* [x] I have reverted any changes to the version number components in both `vss-extension.json` and `task.json`, OR I didn't change them.
