### PR TITLE
Filter comments without source set

### DIFF
--- a/buildAndReleaseTask/prComment.ts
+++ b/buildAndReleaseTask/prComment.ts
@@ -195,6 +195,7 @@ async function updateExistingThread(
     const pulumiCommentThreads = threads.filter(
         (t) =>
             t.status === CommentThreadStatus.Active &&
+            t.properties["source"] !== undefined &&
             t.properties["source"]["$value"] === SOURCE_PULUMI
     );
     // If we found a previous thread, add a comment to it.


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-az-pipelines-task/issues/134.

When searching for comments from the pulumi tool filter out threads without "source" set.