### PR TITLE
chore: Use the latest Azure Native in example

### DIFF
--- a/examples/azure-native-dotnet/azure-dotnet.csproj
+++ b/examples/azure-native-dotnet/azure-dotnet.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change upgrades Azure Native in the example to the latest version, which has [better oidc support](https://github.com/pulumi/pulumi-azure-native/issues/2884), which is needed to run the integration tests that now use oidc for authentication with Azure.