### PR TITLE
Update dotnet example to use 8.0

### DIFF
--- a/examples/azure-native-dotnet/azure-dotnet.csproj
+++ b/examples/azure-native-dotnet/azure-dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
The test pipeline on merge to master is currently failing with

```
  pulumi:pulumi:Stack (pulumi-az-pipelines-task-azure-dotnet-dev):
    You must install or update .NET to run this application.
    App: /home/vsts/work/1/s/examples/azure-native-dotnet/bin/Debug/net6.0/azure-dotnet
    Architecture: x64
    Framework: 'Microsoft.NETCore.App', version '6.0.0' (x64)
    .NET location: /usr/lib/dotnet
    The following frameworks were found:
      8.0.16 at [/usr/lib/dotnet/shared/Microsoft.NETCore.App]
```

https://dev.azure.com/pulumi/Pulumi%20Azure%20Pipelines%20Task/_build/results?buildId=534&view=logs&j=86c4f51f-3948-5d48-5a77-40c0b241e1ef&t=e43b5afd-f7c1-5544-3510-8415c558bba4