### PR TITLE
fix: add warning logs when PR comment fails to be written

### DIFF
--- a/buildAndReleaseTask/prComment.ts
+++ b/buildAndReleaseTask/prComment.ts
@@ -111,29 +111,32 @@ export async function createPrComment(taskConfig: TaskConfig) {
 
     const accessToken = tl.getVariable("System.AccessToken");
     if (!accessToken) {
-        throw new Error(
-            "Job access token is required to create/update PR comment"
-        );
+        tl.warning(tl.loc("Warning_PrComment_MissingAccessToken"));
+        return;
     }
 
     const collectionUri = tl.getVariable("System.CollectionUri");
     if (!collectionUri) {
-        throw new Error("Could not determine the DevOps org's base URI");
+        tl.warning(tl.loc("Warning_PrComment_MissingCollectionUri"));
+        return;
     }
 
     const projectId = tl.getVariable("System.TeamProjectId");
     if (!projectId) {
-        throw new Error("Could not determine the project ID");
+        tl.warning(tl.loc("Warning_PrComment_MissingProjectId"));
+        return;
     }
 
     const repositoryId = tl.getVariable("Build.Repository.ID");
     if (!repositoryId) {
-        throw new Error("Could not determine the repository ID");
+        tl.warning(tl.loc("Warning_PrComment_MissingRepositoryId"));
+        return;
     }
 
     const prId = tl.getVariable("System.PullRequest.PullRequestId");
     if (!prId) {
-        throw new Error("Could not determine the PR ID");
+        tl.warning(tl.loc("Warning_PrComment_MissingPrId"));
+        return;
     }
 
     const buildEnvInfo: BuildEnvInfo = {
@@ -146,9 +149,15 @@ export async function createPrComment(taskConfig: TaskConfig) {
         systemAccessToken: accessToken,
     };
 
-    const authHandler = azdev.getBearerHandler(accessToken);
-    const webApi = new azdev.WebApi(collectionUri, authHandler);
-    const gitApi = await webApi.getGitApi();
+    let gitApi: IGitApi;
+    try {
+        const authHandler = azdev.getBearerHandler(accessToken);
+        const webApi = new azdev.WebApi(collectionUri, authHandler);
+        gitApi = await webApi.getGitApi();
+    } catch (err: any) {
+        tl.warning(tl.loc("Warning_PrComment_GitApiInitFailed", err.message || err));
+        return;
+    }
 
     const pulumiLogs = readFileSync(pathJoin(".", PULUMI_LOG_FILENAME), {
         encoding: "utf-8",
@@ -162,18 +171,28 @@ export async function createPrComment(taskConfig: TaskConfig) {
 
     const useThreads = taskConfig.useThreadedPrComments;
     if (useThreads) {
-        const updated = await updateExistingThread(
-            buildEnvInfo,
-            azureRepoInfo,
-            gitApi,
-            commentBody
-        );
+        let updated: boolean;
+        try {
+            updated = await updateExistingThread(
+                buildEnvInfo,
+                azureRepoInfo,
+                gitApi,
+                commentBody
+            );
+        } catch (err: any) {
+            tl.warning(tl.loc("Warning_PrComment_UpdateThreadFailed", err.message || err));
+            return;
+        }
         if (updated) {
             return;
         }
     }
 
-    await createThread(buildEnvInfo, azureRepoInfo, gitApi, commentBody);
+    try {
+        await createThread(buildEnvInfo, azureRepoInfo, gitApi, commentBody);
+    } catch (err: any) {
+        tl.warning(tl.loc("Warning_PrComment_CreateThreadFailed", err.message || err));
+    }
 }
 
 /**

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -163,7 +163,15 @@
         "Debug_ThreadFound": "Found an existing comment thread created by this task. A new comment will be added to it.",
         "Warning_ExistingCommentThreadNotFound": "Did not find an existing comment thread for Pulumi output. Will start a new one.",
         "Warning_UnSupportedRepositoryType": "Repository type %s is not yet supported for PR comments.",
-        "Warning_NotABuildPipeline": "Ignoring request to create a PR comment. PR comments are only applicable for build pipelines. The pipeline is a %s."
+        "Warning_NotABuildPipeline": "Ignoring request to create a PR comment. PR comments are only applicable for build pipelines. The pipeline is a %s.",
+        "Warning_PrComment_MissingAccessToken": "Skipping PR comment: System.AccessToken is not available. Ensure the job's access token is enabled and mapped as SYSTEM_ACCESSTOKEN.",
+        "Warning_PrComment_MissingCollectionUri": "Skipping PR comment: could not determine the Azure DevOps collection URI (System.CollectionUri).",
+        "Warning_PrComment_MissingProjectId": "Skipping PR comment: could not determine the project ID (System.TeamProjectId).",
+        "Warning_PrComment_MissingRepositoryId": "Skipping PR comment: could not determine the repository ID (Build.Repository.ID).",
+        "Warning_PrComment_MissingPrId": "Skipping PR comment: could not determine the pull request ID (System.PullRequest.PullRequestId). This is expected for non-PR builds.",
+        "Warning_PrComment_GitApiInitFailed": "Skipping PR comment: failed to initialize the Azure DevOps Git API. Error: %s",
+        "Warning_PrComment_UpdateThreadFailed": "Failed to update the existing PR comment thread. Error: %s",
+        "Warning_PrComment_CreateThreadFailed": "Failed to create the PR comment thread. Error: %s"
     },
     "showEnvironmentVariables": true
 }


### PR DESCRIPTION
Closes #135

When `createPrComment` is enabled but the PR comment cannot be written to Azure DevOps, the task previously either threw an unhandled error or let API failures propagate as uncaught exceptions. Users had no indication of why their PR comment was not appearing.

## Changes

### `prComment.ts`
- Replace `throw new Error(...)` with `tl.warning(...)` for all missing-variable checks (`System.AccessToken`, `System.CollectionUri`, `System.TeamProjectId`, `Build.Repository.ID`, `System.PullRequest.PullRequestId`). The task now completes with a warning instead of failing the build, consistent with how other optional features behave.
- Wrap Git API initialization in try/catch — if the API client fails to initialize, emit a warning with the error message.
- Wrap `updateExistingThread()` and `createThread()` calls in try/catch so Azure DevOps API errors are surfaced as actionable warnings.

### `task.json`
- Add 8 new message strings for all new warnings.

## Result

Users now see descriptive warnings in the pipeline log, e.g.:
```
##[warning]Skipping PR comment: System.AccessToken is not available. Ensure the job access token is enabled and mapped as SYSTEM_ACCESSTOKEN.
```
or
```
##[warning]Failed to create the PR comment thread. Error: TF401027: You need the Git repositories read permission.
```